### PR TITLE
fix(user-learning): use unique session ID to prevent context bloat (fixes #11)

### DIFF
--- a/src/services/user-memory-learning.ts
+++ b/src/services/user-memory-learning.ts
@@ -242,7 +242,12 @@ Use the update_user_profile tool to save the ${existingProfile ? "updated" : "ne
     },
   };
 
-  const result = await provider.executeToolCall(systemPrompt, context, toolSchema, "user-profile");
+  const result = await provider.executeToolCall(
+    systemPrompt,
+    context,
+    toolSchema,
+    `user-profile-${Date.now()}`
+  );
 
   if (!result.success || !result.data) {
     throw new Error(result.error || "Failed to analyze user profile");


### PR DESCRIPTION
Fixes #11. This PR resolves the issue where user profile updates would eventually stall due to infinite history accumulation in the `user-profile` session.

