### PR TITLE
feat: add FTS5 full-text search with hybrid ranking

### DIFF
--- a/src/services/sqlite/shard-manager.ts
+++ b/src/services/sqlite/shard-manager.ts
@@ -182,6 +182,16 @@ export class ShardManager {
       )
     `);
 
+    db.run(`
+      CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts USING fts5(
+        content,
+        tags,
+        container_tag UNINDEXED,
+        memory_id UNINDEXED,
+        tokenize='porter unicode61'
+      )
+    `);
+
     db.run(`CREATE INDEX IF NOT EXISTS idx_container_tag ON memories(container_tag)`);
     db.run(`CREATE INDEX IF NOT EXISTS idx_type ON memories(type)`);
     db.run(`CREATE INDEX IF NOT EXISTS idx_created_at ON memories(created_at DESC)`);


### PR DESCRIPTION
## Summary
- add SQLite FTS5 virtual table creation for new shards and migration path for existing shard databases
- index FTS documents on memory insert/delete and add sanitized FTS query search API in vector search service
- add client-level full-text and hybrid search that fuses vector + FTS rankings with reciprocal-rank weighting