### PR TITLE
fix: add common API embedding models to dimensionMap

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -214,6 +214,7 @@ const CONFIG_TEMPLATE = `{
   // Optional: Use OpenAI-compatible API for embeddings
   // "embeddingApiUrl": "https://api.openai.com/v1",
   // "embeddingApiKey": "sk-...",
+  // "embeddingModel": "text-embedding-3-small",  // 1536 dims, auto-detected
   
   // ============================================
   // Web Server Settings
@@ -393,6 +394,7 @@ ensureConfigExists();
 
 function getEmbeddingDimensions(model: string): number {
   const dimensionMap: Record<string, number> = {
+    // Local Xenova models
     "Xenova/nomic-embed-text-v1": 768,
     "Xenova/nomic-embed-text-v1-unsupervised": 768,
     "Xenova/nomic-embed-text-v1-ablated": 768,
@@ -408,6 +410,26 @@ function getEmbeddingDimensions(model: string): number {
     "Xenova/gte-small": 384,
     "Xenova/GIST-small-Embedding-v0": 384,
     "Xenova/text-embedding-ada-002": 1536,
+
+    // OpenAI API models
+    "text-embedding-3-small": 1536,
+    "text-embedding-3-large": 3072,
+    "text-embedding-ada-002": 1536,
+
+    // Cohere API models
+    "embed-english-v3.0": 1024,
+    "embed-multilingual-v3.0": 1024,
+    "embed-english-light-v3.0": 384,
+    "embed-multilingual-light-v3.0": 384,
+
+    // Google API models
+    "text-embedding-004": 768,
+    "text-multilingual-embedding-002": 768,
+
+    // Voyage AI models
+    "voyage-3": 1024,
+    "voyage-3-lite": 512,
+    "voyage-code-3": 1024,
   };
   return dimensionMap[model] || 768;
 }


### PR DESCRIPTION
## Summary

Fixes #27 — Dimension mismatch when using API embedding models not in `dimensionMap`.

## Problem

When using API-based embedding models (e.g. `text-embedding-3-small` via `embeddingApiUrl`), the plugin falls back to default 768 dimensions because these model names are not in `dimensionMap`. The API returns 1536-dimensional vectors, causing:

```
Dimension mismatch for inserted vector for the "embedding" column.
Expected 768 dimensions but received 1536.
```

## Changes

### 1. Added API embedding models to `dimensionMap`

```typescript
// OpenAI API models
"text-embedding-3-small": 1536,
"text-embedding-3-large": 3072,
"text-embedding-ada-002": 1536,

// Cohere API models
"embed-english-v3.0": 1024,
"embed-multilingual-v3.0": 1024,
"embed-english-light-v3.0": 384,
"embed-multilingual-light-v3.0": 384,

// Google API models
"text-embedding-004": 768,
"text-multilingual-embedding-002": 768,

// Voyage AI models
"voyage-3": 1024,
"voyage-3-lite": 512,
"voyage-code-3": 1024,
```

### 2. Updated config template comments

Added example for API embedding usage with auto-detected dimensions.

## Testing

Tested with `text-embedding-3-small` via GitHub Models API (`https://models.inference.ai.azure.com`). Before this fix, `embeddingDimensions: 1536` had to be manually set in config. After this fix, dimensions are auto-detected from the model name.

## Note

Users with **custom or unlisted API embedding models** can still use the `embeddingDimensions` config override as a fallback.