### PR TITLE
fix: auto-recreate database tables when shard DB file is missing

### DIFF
--- a/src/services/sqlite/shard-manager.ts
+++ b/src/services/sqlite/shard-manager.ts
@@ -228,7 +228,7 @@ export class ShardManager {
    * re-initialize them. This handles cases where the DB file exists but
    * was corrupted or partially created.
    */
-  ensureShardTables(shard: ShardInfo): void {
+  private ensureShardTables(shard: ShardInfo): void {
     try {
       const db = connectionManager.getConnection(shard.dbPath);
       this.initShardDb(db);


### PR DESCRIPTION
## Summary

Fixes #28 — Database tables not auto-recreated after data directory deletion.

## Problem

When shard DB files are deleted externally (e.g. to reset after changing embedding model/dimensions), `metadata.db` still contains stale shard records pointing to the deleted files. The plugin then tries to use these non-existent databases, resulting in persistent errors:

```
addMemory: error: {"error":"no such table: memories"}
```

The only workaround was to delete the **entire** `~/.opencode-mem/data/` directory (including `metadata.db`), but even this was unreliable.

## Root Cause

In `getWriteShard()`, when `getActiveShard()` returns a shard record from `metadata.db`, the code trusts it blindly without checking if the actual DB file exists or contains the required tables.

## Changes

### 1. Added `isShardValid()` method
Checks two conditions:
- The shard DB **file exists** on disk (`existsSync`)
- The DB **contains the `memories` table** (queries `sqlite_master`)

### 2. Added `ensureShardTables()` method
Public method that re-initializes all required tables on an existing shard DB. Useful for recovering from corrupted or partially created databases.

### 3. Updated `getWriteShard()` flow
```
Before:
  getActiveShard() → if exists, use it directly → FAILS if file deleted

After:
  getActiveShard() → if exists, validate it:
    → if valid: use it ✅
    → if invalid: close connection, delete stale record, create fresh shard ✅
```

## Testing

Tested on Windows 11 with the following scenario:
1. Used opencode-mem normally (memories stored)
2. Closed OpenCode
3. Deleted `~/.opencode-mem/data/projects/` directory
4. Restarted OpenCode
5. **Before fix:** `no such table: memories` error
6. **After fix:** Fresh shard auto-created, memories work normally