### PR TITLE
fix: replace Worker thread with direct Bun.serve() for Windows compatibility

### DIFF
--- a/src/services/web-server.ts
+++ b/src/services/web-server.ts
@@ -1,6 +1,32 @@
+import { readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { log } from "./logger.js";
+import {
+  handleListTags,
+  handleListMemories,
+  handleAddMemory,
+  handleDeleteMemory,
+  handleBulkDelete,
+  handleUpdateMemory,
+  handleSearch,
+  handleStats,
+  handlePinMemory,
+  handleUnpinMemory,
+  handleRunCleanup,
+  handleRunDeduplication,
+  handleDetectMigration,
+  handleRunMigration,
+  handleDetectTagMigration,
+  handleRunTagMigrationBatch,
+  handleGetTagMigrationProgress,
+  handleDeletePrompt,
+  handleBulkDeletePrompts,
+  handleGetUserProfile,
+  handleGetProfileChangelog,
+  handleGetProfileSnapshot,
+  handleRefreshProfile,
+} from "./api-handlers.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -11,21 +37,8 @@ interface WebServerConfig {
   enabled: boolean;
 }
 
-interface WorkerMessage {
-  type: "start" | "stop" | "status";
-  port?: number;
-  host?: string;
-}
-
-interface WorkerResponse {
-  type: "started" | "stopped" | "error" | "status";
-  url?: string;
-  error?: string;
-  running?: boolean;
-}
-
 export class WebServer {
-  private worker: Worker | null = null;
+  private server: ReturnType<typeof Bun.serve> | null = null;
   private config: WebServerConfig;
   private isOwner: boolean = false;
   private startPromise: Promise<void> | null = null;
@@ -55,78 +68,29 @@ export class WebServer {
     }
 
     try {
-      const workerPath = join(__dirname, "web-server-worker.js");
-      this.worker = new Worker(workerPath);
-
-      const startedPromise = new Promise<void>((resolve, reject) => {
-        const timeout = setTimeout(() => {
-          reject(new Error("Worker start timeout"));
-        }, 10000);
-
-        this.worker!.onmessage = (event: MessageEvent<WorkerResponse>) => {
-          clearTimeout(timeout);
-          const response = event.data;
-
-          if (response.type === "started") {
-            this.isOwner = true;
-            resolve();
-          } else if (response.type === "error") {
-            const errorMsg = response.error || "Unknown error";
-
-            if (
-              errorMsg.includes("EADDRINUSE") ||
-              errorMsg.includes("address already in use") ||
-              /^Error: Failed to start server\. Is port \d+ in use\?$/.test(errorMsg)
-            ) {
-              this.isOwner = false;
-              resolve();
-            } else {
-              log("Web server worker error", { error: errorMsg });
-              reject(new Error(errorMsg));
-            }
-          }
-        };
-
-        this.worker!.onerror = (error: ErrorEvent) => {
-          clearTimeout(timeout);
-          const errorDetails = {
-            message: error.message || "Unknown error",
-            filename: error.filename || "unknown",
-            lineno: error.lineno || 0,
-            colno: error.colno || 0,
-            error: error.error ? String(error.error) : "no error object",
-            type: error.type || "error",
-          };
-          log("Web server worker error (detailed)", errorDetails);
-
-          const errorMsg = error.message
-            ? `${error.message} (at ${error.filename}:${error.lineno}:${error.colno})`
-            : error.error
-              ? String(error.error)
-              : `Worker failed: ${JSON.stringify(errorDetails)}`;
-          reject(new Error(errorMsg));
-        };
-      });
-
-      this.worker.postMessage({
-        type: "start",
+      this.server = Bun.serve({
         port: this.config.port,
-        host: this.config.host,
-      } as WorkerMessage);
-
-      await startedPromise;
-
-      if (!this.isOwner) {
-        this.startHealthCheckLoop();
-      }
+        hostname: this.config.host,
+        fetch: this.handleRequest.bind(this),
+      });
+      this.isOwner = true;
     } catch (error) {
-      this.isOwner = false;
-      if (this.worker) {
-        this.worker.terminate();
-        this.worker = null;
+      const errorMsg = String(error);
+
+      if (
+        errorMsg.includes("EADDRINUSE") ||
+        errorMsg.includes("address already in use") ||
+        /Failed to start server.*Is port \d+ in use/.test(errorMsg)
+      ) {
+        this.isOwner = false;
+        this.server = null;
+        this.startHealthCheckLoop();
+      } else {
+        this.isOwner = false;
+        this.server = null;
+        log("Web server failed to start", { error: errorMsg });
+        throw error;
       }
-      log("Web server failed to start", { error: String(error) });
-      throw error;
     }
   }
 
@@ -163,15 +127,19 @@ export class WebServer {
     }
 
     try {
+      // Reset startPromise so _start() can run again
+      this.startPromise = null;
       await this._start();
-      this.isOwner = true;
-      log("Web server takeover successful", { port: this.config.port });
 
-      if (this.onTakeoverCallback) {
-        try {
-          await this.onTakeoverCallback();
-        } catch (error) {
-          log("Takeover callback error", { error: String(error) });
+      if (this.isOwner) {
+        log("Web server takeover successful", { port: this.config.port });
+
+        if (this.onTakeoverCallback) {
+          try {
+            await this.onTakeoverCallback();
+          } catch (error) {
+            log("Takeover callback error", { error: String(error) });
+          }
         }
       }
     } catch (error) {
@@ -182,40 +150,17 @@ export class WebServer {
   async stop(): Promise<void> {
     this.stopHealthCheckLoop();
 
-    if (!this.isOwner || !this.worker) {
+    if (!this.isOwner || !this.server) {
       return;
     }
 
-    return new Promise<void>((resolve) => {
-      const timeout = setTimeout(() => {
-        if (this.worker) {
-          this.worker.terminate();
-          this.worker = null;
-        }
-        resolve();
-      }, 5000);
-
-      this.worker!.onmessage = (event: MessageEvent<WorkerResponse>) => {
-        clearTimeout(timeout);
-        const response = event.data;
-
-        if (response.type === "stopped") {
-          if (this.worker) {
-            this.worker.terminate();
-            this.worker = null;
-          }
-          resolve();
-        }
-      };
-
-      this.worker!.postMessage({
-        type: "stop",
-      } as WorkerMessage);
-    });
+    this.server.stop();
+    this.server = null;
+    this.isOwner = false;
   }
 
   isRunning(): boolean {
-    return this.worker !== null;
+    return this.server !== null;
   }
 
   isServerOwner(): boolean {
@@ -236,6 +181,259 @@ export class WebServer {
     } catch {
       return false;
     }
+  }
+
+  // --- HTTP request handling (inlined from web-server-worker.ts) ---
+
+  private async handleRequest(req: Request): Promise<Response> {
+    const url = new URL(req.url);
+    const path = url.pathname;
+    const method = req.method;
+
+    try {
+      if (path === "/" || path === "/index.html") {
+        return this.serveStaticFile("index.html", "text/html");
+      }
+
+      if (path === "/styles.css") {
+        return this.serveStaticFile("styles.css", "text/css");
+      }
+
+      if (path === "/app.js") {
+        return this.serveStaticFile("app.js", "application/javascript");
+      }
+
+      if (path === "/favicon.ico") {
+        return this.serveStaticFile("favicon.ico", "image/x-icon");
+      }
+
+      if (path === "/api/tags" && method === "GET") {
+        const result = await handleListTags();
+        return this.jsonResponse(result);
+      }
+
+      if (path === "/api/memories" && method === "GET") {
+        const tag = url.searchParams.get("tag") || undefined;
+        const page = parseInt(url.searchParams.get("page") || "1");
+        const pageSize = parseInt(url.searchParams.get("pageSize") || "20");
+        const includePrompts = url.searchParams.get("includePrompts") !== "false";
+        const result = await handleListMemories(tag, page, pageSize, includePrompts);
+        return this.jsonResponse(result);
+      }
+
+      if (path === "/api/memories" && method === "POST") {
+        const body = (await req.json()) as any;
+        const result = await handleAddMemory(body);
+        return this.jsonResponse(result);
+      }
+
+      if (path.startsWith("/api/memories/") && method === "DELETE") {
+        const parts = path.split("/");
+        const id = parts[3];
+        if (!id || id === "bulk-delete") {
+          return this.jsonResponse({ success: false, error: "Invalid ID" });
+        }
+        const cascade = url.searchParams.get("cascade") === "true";
+        const result = await handleDeleteMemory(id, cascade);
+        return this.jsonResponse(result);
+      }
+
+      if (path.startsWith("/api/memories/") && method === "PUT") {
+        const id = path.split("/").pop();
+        if (!id) {
+          return this.jsonResponse({ success: false, error: "Invalid ID" });
+        }
+        const body = (await req.json()) as any;
+        const result = await handleUpdateMemory(id, body);
+        return this.jsonResponse(result);
+      }
+
+      if (path === "/api/memories/bulk-delete" && method === "POST") {
+        const body = (await req.json()) as any;
+        const cascade = body.cascade !== false;
+        const result = await handleBulkDelete(body.ids || [], cascade);
+        return this.jsonResponse(result);
+      }
+
+      if (path === "/api/search" && method === "GET") {
+        const query = url.searchParams.get("q");
+        const tag = url.searchParams.get("tag") || undefined;
+        const page = parseInt(url.searchParams.get("page") || "1");
+        const pageSize = parseInt(url.searchParams.get("pageSize") || "20");
+
+        if (!query) {
+          return this.jsonResponse({ success: false, error: "query parameter required" });
+        }
+
+        const result = await handleSearch(query, tag, page, pageSize);
+        return this.jsonResponse(result);
+      }
+
+      if (path === "/api/stats" && method === "GET") {
+        const result = await handleStats();
+        return this.jsonResponse(result);
+      }
+
+      if (path.match(/^\/api\/memories\/[^/]+\/pin$/) && method === "POST") {
+        const id = path.split("/")[3];
+        if (!id) {
+          return this.jsonResponse({ success: false, error: "Invalid ID" });
+        }
+        const result = await handlePinMemory(id);
+        return this.jsonResponse(result);
+      }
+
+      if (path.match(/^\/api\/memories\/[^/]+\/unpin$/) && method === "POST") {
+        const id = path.split("/")[3];
+        if (!id) {
+          return this.jsonResponse({ success: false, error: "Invalid ID" });
+        }
+        const result = await handleUnpinMemory(id);
+        return this.jsonResponse(result);
+      }
+
+      if (path === "/api/cleanup" && method === "POST") {
+        const result = await handleRunCleanup();
+        return this.jsonResponse(result);
+      }
+
+      if (path === "/api/deduplicate" && method === "POST") {
+        const result = await handleRunDeduplication();
+        return this.jsonResponse(result);
+      }
+
+      if (path === "/api/migration/detect" && method === "GET") {
+        const result = await handleDetectMigration();
+        return this.jsonResponse(result);
+      }
+
+      if (path === "/api/migration/tags/detect" && method === "GET") {
+        const result = await handleDetectTagMigration();
+        return this.jsonResponse(result);
+      }
+
+      if (path === "/api/migration/tags/run-batch" && method === "POST") {
+        const body = (await req.json()) as any;
+        const batchSize = body?.batchSize || 5;
+        const result = await handleRunTagMigrationBatch(batchSize);
+        return this.jsonResponse(result);
+      }
+
+      if (path === "/api/migration/tags/progress" && method === "GET") {
+        const result = await handleGetTagMigrationProgress();
+        return this.jsonResponse(result);
+      }
+
+      if (path === "/api/migration/run" && method === "POST") {
+        const body = (await req.json()) as any;
+        const strategy = body.strategy || "fresh-start";
+        if (strategy !== "fresh-start" && strategy !== "re-embed") {
+          return this.jsonResponse({ success: false, error: "Invalid strategy" });
+        }
+        const result = await handleRunMigration(strategy);
+        return this.jsonResponse(result);
+      }
+
+      if (path.startsWith("/api/prompts/") && method === "DELETE") {
+        const parts = path.split("/");
+        const id = parts[3];
+        if (!id || id === "bulk-delete") {
+          return this.jsonResponse({ success: false, error: "Invalid ID" });
+        }
+        const cascade = url.searchParams.get("cascade") === "true";
+        const result = await handleDeletePrompt(id, cascade);
+        return this.jsonResponse(result);
+      }
+
+      if (path === "/api/prompts/bulk-delete" && method === "POST") {
+        const body = (await req.json()) as any;
+        const cascade = body.cascade !== false;
+        const result = await handleBulkDeletePrompts(body.ids || [], cascade);
+        return this.jsonResponse(result);
+      }
+
+      if (path === "/api/user-profile" && method === "GET") {
+        const userId = url.searchParams.get("userId") || undefined;
+        const result = await handleGetUserProfile(userId);
+        return this.jsonResponse(result);
+      }
+
+      if (path === "/api/user-profile/changelog" && method === "GET") {
+        const profileId = url.searchParams.get("profileId");
+        const limit = parseInt(url.searchParams.get("limit") || "5");
+        if (!profileId) {
+          return this.jsonResponse({ success: false, error: "profileId parameter required" });
+        }
+        const result = await handleGetProfileChangelog(profileId, limit);
+        return this.jsonResponse(result);
+      }
+
+      if (path === "/api/user-profile/snapshot" && method === "GET") {
+        const changelogId = url.searchParams.get("chlogId");
+        if (!changelogId) {
+          return this.jsonResponse({ success: false, error: "changelogId parameter required" });
+        }
+        const result = await handleGetProfileSnapshot(changelogId);
+        return this.jsonResponse(result);
+      }
+
+      if (path === "/api/user-profile/refresh" && method === "POST") {
+        const body = (await req.json().catch(() => ({}))) as any;
+        const userId = body.userId || undefined;
+        const result = await handleRefreshProfile(userId);
+        return this.jsonResponse(result);
+      }
+
+      return new Response("Not Found", { status: 404 });
+    } catch (error) {
+      return this.jsonResponse(
+        {
+          success: false,
+          error: String(error),
+        },
+        500
+      );
+    }
+  }
+
+  private serveStaticFile(filename: string, contentType: string): Response {
+    try {
+      const webDir = join(__dirname, "..", "web");
+      const filePath = join(webDir, filename);
+
+      if (contentType.startsWith("image/")) {
+        const content = readFileSync(filePath);
+        return new Response(content, {
+          headers: {
+            "Content-Type": contentType,
+            "Cache-Control": "public, max-age=86400",
+          },
+        });
+      }
+
+      const content = readFileSync(filePath, "utf-8");
+
+      return new Response(content, {
+        headers: {
+          "Content-Type": contentType,
+          "Cache-Control": "no-cache",
+        },
+      });
+    } catch (error) {
+      return new Response("File not found", { status: 404 });
+    }
+  }
+
+  private jsonResponse(data: any, status: number = 200): Response {
+    return new Response(JSON.stringify(data), {
+      status,
+      headers: {
+        "Content-Type": "application/json",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+        "Access-Control-Allow-Headers": "Content-Type",
+      },
+    });
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes #32 — Web server is unresponsive on Windows because `Bun.serve()` inside a Worker thread accepts TCP connections but the `fetch` handler never fires.

## Problem

On Windows, the current Worker-based web server architecture has a critical bug:

1. `web-server.ts` spawns a Worker thread running `web-server-worker.ts`
2. The Worker calls `Bun.serve({port, hostname, fetch: handleRequest})`
3. The port binds successfully (`netstat` shows LISTENING)
4. **But the `fetch` callback never fires** — HTTP requests are accepted at TCP level but never processed
5. Browsers and `curl` connect successfully but receive zero bytes back

This appears to be a Bun runtime issue with Worker threads + `Bun.serve()` on Windows.

## Solution

Replace the Worker thread pattern with **direct `Bun.serve()` in the main thread**:

- Inline the request handling logic (from `web-server-worker.ts`) directly into `web-server.ts` as class methods
- Use `Bun.serve()` directly in `_start()` instead of spawning a Worker
- Use `server.stop()` in `stop()` instead of posting messages to a Worker
- Keep all existing functionality: static file serving, API routes, health checks, ownership takeover

## Changes

- **`src/services/web-server.ts`**: Rewrote to use direct `Bun.serve()` with inlined request handling. Removed Worker dependency. Added `handleRequest()`, `serveStaticFile()`, `jsonResponse()` as class methods.

## Testing

After applying this fix locally to the compiled `dist/services/web-server.js`:
- ✅ `curl http://127.0.0.1:4747/` returns Memory Explorer HTML
- ✅ `curl http://127.0.0.1:4747/api/stats` returns valid JSON
- ✅ All API endpoints respond correctly
- ✅ Browser loads Web UI successfully