### PR TITLE
Unify project memory scope across git worktrees

### DIFF
--- a/src/services/tags.ts
+++ b/src/services/tags.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { execSync } from "node:child_process";
 import { CONFIG } from "../config.js";
-import { sep, normalize, resolve, isAbsolute } from "node:path";
+import { sep, normalize, resolve, isAbsolute, basename, dirname } from "node:path";
 
 function sha256(input: string): string {
   return createHash("sha256").update(input).digest("hex").slice(0, 16);
@@ -19,7 +19,10 @@ export interface TagInfo {
 
 export function getGitEmail(): string | null {
   try {
-    const email = execSync("git config user.email", { encoding: "utf-8" }).trim();
+    const email = execSync("git config user.email", {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
     return email || null;
   } catch {
     return null;
@@ -28,7 +31,10 @@ export function getGitEmail(): string | null {
 
 export function getGitName(): string | null {
   try {
-    const name = execSync("git config user.name", { encoding: "utf-8" }).trim();
+    const name = execSync("git config user.name", {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
     return name || null;
   } catch {
     return null;
@@ -40,6 +46,7 @@ export function getGitRepoUrl(directory: string): string | null {
     const url = execSync("git config --get remote.origin.url", {
       encoding: "utf-8",
       cwd: directory,
+      stdio: ["ignore", "pipe", "ignore"],
     }).trim();
     return url || null;
   } catch {
@@ -52,6 +59,7 @@ export function getGitCommonDir(directory: string): string | null {
     const commonDir = execSync("git rev-parse --git-common-dir", {
       encoding: "utf-8",
       cwd: directory,
+      stdio: ["ignore", "pipe", "ignore"],
     }).trim();
 
     if (!commonDir) {
@@ -69,11 +77,26 @@ export function getGitTopLevel(directory: string): string | null {
     const topLevel = execSync("git rev-parse --show-toplevel", {
       encoding: "utf-8",
       cwd: directory,
+      stdio: ["ignore", "pipe", "ignore"],
     }).trim();
     return topLevel || null;
   } catch {
     return null;
   }
+}
+
+export function getProjectRoot(directory: string): string {
+  const commonDir = getGitCommonDir(directory);
+  if (commonDir && basename(commonDir) === ".git") {
+    return dirname(commonDir);
+  }
+
+  const topLevel = getGitTopLevel(directory);
+  if (topLevel) {
+    return topLevel;
+  }
+
+  return directory;
 }
 
 export function getProjectIdentity(directory: string): string {
@@ -120,15 +143,15 @@ export function getUserTagInfo(): TagInfo {
 }
 
 export function getProjectTagInfo(directory: string): TagInfo {
-  const topLevel = getGitTopLevel(directory) || directory;
-  const projectName = getProjectName(topLevel);
+  const projectRoot = getProjectRoot(directory);
+  const projectName = getProjectName(projectRoot);
   const gitRepoUrl = getGitRepoUrl(directory);
-  const projectIdentity = getProjectIdentity(directory);
+  const projectIdentity = getProjectIdentity(projectRoot);
 
   return {
     tag: `${CONFIG.containerTagPrefix}_project_${sha256(projectIdentity)}`,
-    displayName: topLevel,
-    projectPath: topLevel,
+    displayName: projectRoot,
+    projectPath: projectRoot,
     projectName,
     gitRepoUrl: gitRepoUrl || undefined,
   };

--- a/tests/project-scope.test.ts
+++ b/tests/project-scope.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { basename, join } from "node:path";
+import { tmpdir } from "node:os";
+import { execSync } from "node:child_process";
+import { getProjectTagInfo } from "../src/services/tags.js";
+
+const createdDirs: string[] = [];
+
+function run(command: string, cwd: string): void {
+  execSync(command, { cwd, stdio: "pipe" });
+}
+
+function createRepoWithWorktree(): { repoDir: string; worktreeDir: string } {
+  const repoDir = mkdtempSync(join(tmpdir(), "opencode-mem-scope-"));
+  createdDirs.push(repoDir);
+
+  run("git init", repoDir);
+  run("git config user.email test@example.com", repoDir);
+  run("git config user.name Test User", repoDir);
+
+  writeFileSync(join(repoDir, "README.md"), "# test\n", "utf-8");
+  run("git add README.md", repoDir);
+  run('git commit -m "init"', repoDir);
+
+  const worktreeRoot = join(repoDir, ".worktrees");
+  mkdirSync(worktreeRoot, { recursive: true });
+  const worktreeDir = join(worktreeRoot, "feature-a");
+  run(`git worktree add "${worktreeDir}" -b feature-a`, repoDir);
+
+  return { repoDir, worktreeDir };
+}
+
+afterEach(() => {
+  while (createdDirs.length > 0) {
+    const dir = createdDirs.pop();
+    if (dir) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+describe("project scope identity", () => {
+  it("uses one project tag across worktrees in the same repo", () => {
+    const { repoDir, worktreeDir } = createRepoWithWorktree();
+
+    const mainTag = getProjectTagInfo(repoDir);
+    const worktreeTag = getProjectTagInfo(worktreeDir);
+
+    expect(mainTag.tag).toBe(worktreeTag.tag);
+    expect(mainTag.projectPath).toBe(worktreeTag.projectPath);
+    expect(mainTag.projectName).toBe(basename(repoDir));
+  });
+
+  it("uses different project tags for unrelated non-git directories", () => {
+    const left = mkdtempSync(join(tmpdir(), "opencode-mem-left-"));
+    const right = mkdtempSync(join(tmpdir(), "opencode-mem-right-"));
+    createdDirs.push(left, right);
+
+    const leftTag = getProjectTagInfo(left);
+    const rightTag = getProjectTagInfo(right);
+
+    expect(leftTag.tag).not.toBe(rightTag.tag);
+  });
+
+  it("uses the same project tag from nested paths inside the same repo", () => {
+    const { repoDir } = createRepoWithWorktree();
+    const nestedDir = join(repoDir, "src", "features", "memory");
+    mkdirSync(nestedDir, { recursive: true });
+
+    const rootTag = getProjectTagInfo(repoDir);
+    const nestedTag = getProjectTagInfo(nestedDir);
+
+    expect(rootTag.tag).toBe(nestedTag.tag);
+    expect(rootTag.projectPath).toBe(nestedTag.projectPath);
+  });
+});


### PR DESCRIPTION
## Summary
- Derive project memory scope from repository identity instead of current working directory path.
- Resolve project metadata (`projectPath`, `displayName`, `projectName`) from a canonical project root so linked worktrees map to the same project context.
- Suppress stderr noise from git metadata probes in non-git contexts.
- Add regression tests for:
  - main checkout and linked worktree scope parity,
  - nested path scope parity inside the same repo,
  - non-git directory isolation.
## Why
When using git worktrees, each worktree has a different filesystem path but represents the same repository. Memory scoping by raw directory path duplicates project memory and fragments context. This change keeps project memory shared across worktrees while preserving path-based fallback behavior for non-git directories.
## Testing
- `bun test ./tests/project-scope.test.ts`
- `bun test ./tests/windows-path.test.ts`
- `npm run typecheck`
- `npx prettier --check "src/services/tags.ts" "tests/project-scope.test.ts"