### PR TITLE
feat: replace hnswlib-node with hnswlib-wasm for cross-platform compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@opencode-ai/plugin": "^1.0.162",
     "@xenova/transformers": "^2.17.2",
     "franc-min": "^6.2.0",
-    "hnswlib-node": "^3.0.0",
+    "hnswlib-wasm": "^0.8.2",
     "iso-639-3": "^3.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Replace `hnswlib-node` (native C++ addon) with `hnswlib-wasm` (WebAssembly) to eliminate the need for Visual Studio Build Tools / C++ compiler on Windows.

## Problem

`hnswlib-node` requires native compilation via `node-gyp`, which demands:
- Visual Studio Build Tools (~2-3 GB download)
- Python 3
- MSVC C++ compiler

This is a significant barrier for Windows users who just want to install and use the plugin.

## Solution

Replace `hnswlib-node ^3.0.0` with `hnswlib-wasm ^0.8.2`. This is based on the author's own wasm implementation from commit `d5581bb`, adapted for the current v2.11.3 dual-index architecture.

### Changes

**`package.json`**:
- `hnswlib-node ^3.0.0` → `hnswlib-wasm ^0.8.2`

**`src/services/sqlite/hnsw-index.ts`**:
- Lazy async import for `hnswlib-wasm` module
- 3-arg constructor (`"cosine", dims, maxElements`) instead of separate `initIndex()`
- `readIndex()` / `writeIndex()` are sync (no `await`)
- `addPoint()` and `searchKnn()` accept `Float32Array` directly (removed `vectorToArray()` helper)

### Verification

- TypeScript: `npx tsc --noEmit` — zero errors
- `npm install` — clean, no native compilation needed
- Pre-commit hooks (prettier) — passed