### PR TITLE
fix: resolve symlinks in git-common-dir for worktree support

### DIFF
--- a/src/services/tags.ts
+++ b/src/services/tags.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import { execSync } from "node:child_process";
 import { CONFIG } from "../config.js";
 import { sep, normalize, resolve, isAbsolute, basename, dirname } from "node:path";
+import { realpathSync, existsSync } from "node:fs";
 
 function sha256(input: string): string {
   return createHash("sha256").update(input).digest("hex").slice(0, 16);
@@ -66,7 +67,15 @@ export function getGitCommonDir(directory: string): string | null {
       return null;
     }
 
-    return isAbsolute(commonDir) ? normalize(commonDir) : normalize(resolve(directory, commonDir));
+    const resolved = isAbsolute(commonDir)
+      ? normalize(commonDir)
+      : normalize(resolve(directory, commonDir));
+
+    if (existsSync(resolved)) {
+      return realpathSync(resolved);
+    }
+
+    return resolved;
   } catch {
     return null;
   }


### PR DESCRIPTION
## Problem

When using git worktree on macOS (where `/tmp` is a symlink to `/private/tmp`), the `git-common-dir` path returned by git differs between the main repo and worktrees:

- **Main repo**: returns `.git` → resolved to `/tmp/worktree-test/main/.git`
- **Feature worktree**: returns `/private/tmp/worktree-test/main/.git` (absolute path)

This causes different project tags to be generated, preventing memory sharing between worktrees of the same repository.

## Solution

Use `realpathSync` to resolve symlinks in the `getGitCommonDir` function, ensuring consistent paths regardless of whether git returns a relative or absolute path, or whether the path contains symlinks.

## Testing

```bash
# Before fix
Main repo tag:      opencode_project_34e2192f1926e08d
Feature worktree:   opencode_project_834e8685c25e514b
# Different tags → memories not shared ❌

# After fix
Main repo tag:      opencode_project_834e8685c25e514b
Feature worktree:   opencode_project_834e8685c25e514b
# Same tags → memories shared ✅
```

## Changes

- Added `realpathSync` and `existsSync` imports from `node:fs`
- Modified `getGitCommonDir` to resolve symlinks before returning the path

Fixes #51