### PR TITLE
feat: add memoryExtraParams for custom API request body parameters

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -41,6 +41,7 @@ interface OpenCodeMemConfig {
   memoryApiUrl?: string;
   memoryApiKey?: string;
   memoryTemperature?: number | false;
+  memoryExtraParams?: Record<string, unknown>;
   vectorBackend?: "usearch-first" | "usearch" | "exact-scan";
   aiSessionRetentionDays?: number;
   webServerEnabled?: boolean;
@@ -83,6 +84,7 @@ const DEFAULTS: Required<
     | "memoryApiKey"
     | "memoryProvider"
     | "memoryTemperature"
+    | "memoryExtraParams"
     | "autoCaptureLanguage"
     | "userEmailOverride"
     | "userNameOverride"
@@ -95,6 +97,7 @@ const DEFAULTS: Required<
   memoryApiKey?: string;
   memoryProvider?: "openai-chat" | "openai-responses" | "anthropic";
   memoryTemperature?: number | false;
+  memoryExtraParams?: Record<string, unknown>;
   vectorBackend?: "usearch-first" | "usearch" | "exact-scan";
   autoCaptureLanguage?: string;
   userEmailOverride?: string;
@@ -294,6 +297,12 @@ const CONFIG_TEMPLATE = `{
   // Set to false and add "memoryTemperature": false in config when using such models
   "memoryTemperature": 0.3,
 
+  // Extra parameters to include in API request body
+  // Useful for local inference servers (e.g. llama-server with --jinja) that support
+  // additional parameters like disabling thinking/reasoning mode
+  // Example for Qwen3 models: { "enable_thinking": false }
+  // "memoryExtraParams": {},
+
   // Language for auto-capture summaries (default: "auto" for auto-detection)
   // Options: "auto", "en", "id", "zh", "ja", "es", "fr", "de", "ru", "pt", "ar", "ko"
   // "autoCaptureLanguage": "auto",
@@ -449,6 +458,7 @@ export const CONFIG = {
   memoryApiUrl: fileConfig.memoryApiUrl,
   memoryApiKey: resolveSecretValue(fileConfig.memoryApiKey),
   memoryTemperature: fileConfig.memoryTemperature,
+  memoryExtraParams: fileConfig.memoryExtraParams,
   vectorBackend: (fileConfig.vectorBackend ?? "usearch-first") as
     | "usearch-first"
     | "usearch"

--- a/src/services/ai/provider-config.ts
+++ b/src/services/ai/provider-config.ts
@@ -5,6 +5,7 @@ interface MemoryProviderRuntimeConfig {
   memoryApiUrl?: string;
   memoryApiKey?: string;
   memoryTemperature?: number | false;
+  memoryExtraParams?: Record<string, unknown>;
   autoCaptureMaxIterations?: number;
   autoCaptureIterationTimeout?: number;
 }
@@ -27,6 +28,7 @@ export function buildMemoryProviderConfig(
     apiUrl: config.memoryApiUrl,
     apiKey: config.memoryApiKey,
     memoryTemperature: config.memoryTemperature,
+    extraParams: config.memoryExtraParams,
     maxIterations: overrides.maxIterations ?? config.autoCaptureMaxIterations,
     iterationTimeout: overrides.iterationTimeout ?? config.autoCaptureIterationTimeout,
   };

--- a/src/services/ai/providers/base-provider.ts
+++ b/src/services/ai/providers/base-provider.ts
@@ -13,6 +13,7 @@ export interface ProviderConfig {
   iterationTimeout?: number;
   maxTokens?: number;
   memoryTemperature?: number | false;
+  extraParams?: Record<string, unknown>;
 }
 
 export abstract class BaseAIProvider {

--- a/src/services/ai/providers/openai-chat-completion.ts
+++ b/src/services/ai/providers/openai-chat-completion.ts
@@ -175,6 +175,10 @@ export class OpenAIChatCompletionProvider extends BaseAIProvider {
           requestBody.temperature = this.config.memoryTemperature ?? 0.3;
         }
 
+        if (this.config.extraParams) {
+          Object.assign(requestBody, this.config.extraParams);
+        }
+
         const headers: Record<string, string> = {
           "Content-Type": "application/json",
         };

--- a/src/services/ai/providers/openai-responses.ts
+++ b/src/services/ai/providers/openai-responses.ts
@@ -80,6 +80,10 @@ export class OpenAIResponsesProvider extends BaseAIProvider {
           requestBody.instructions = systemPrompt;
         }
 
+        if (this.config.extraParams) {
+          Object.assign(requestBody, this.config.extraParams);
+        }
+
         const response = await fetch(`${this.config.apiUrl}/responses`, {
           method: "POST",
           headers: {


### PR DESCRIPTION
## Summary

- Adds a `memoryExtraParams` config option that gets spread into the API request body
- Supports both OpenAI Chat Completion and Responses providers
- Enables local inference servers (e.g. llama-server with `--jinja`) to receive additional parameters

## Use Case

When using local models like Qwen3 via llama-server, the model defaults to thinking/reasoning mode which wastes tokens on chain-of-thought that isn't needed for memory extraction. With this change, users can disable it:

```json
{
  "memoryExtraParams": {
    "chat_template_kwargs": { "enable_thinking": false }
  }
}
```

This is generic enough to support any additional request body parameters that specific inference servers may need.

## Changes

- `src/config.ts` — Added `memoryExtraParams` to config interface, DEFAULTS omit list, CONFIG export, and config template documentation
- `src/services/ai/provider-config.ts` — Threads `memoryExtraParams` through to `ProviderConfig`
- `src/services/ai/providers/base-provider.ts` — Added `extraParams` to `ProviderConfig` interface
- `src/services/ai/providers/openai-chat-completion.ts` — Spreads `extraParams` into request body
- `src/services/ai/providers/openai-responses.ts` — Spreads `extraParams` into request body

## Testing

- TypeScript typecheck passes (`bun run typecheck`)
- Verified with llama-server + Qwen3.5-35B: without `chat_template_kwargs`, all tokens go to reasoning; with it, tool calling works correctly with zero wasted tokens