### PR TITLE
fix(embedding): skip warmup for remote providers

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "opencode-plugin",

--- a/src/services/embedding.ts
+++ b/src/services/embedding.ts
@@ -44,6 +44,10 @@ export class EmbeddingService {
 
   async warmup(progressCallback?: (progress: any) => void): Promise<void> {
     if (this.isWarmedUp) return;
+    if (CONFIG.embeddingApiUrl && CONFIG.embeddingApiKey) {
+      this.isWarmedUp = true;
+      return;
+    }
     if (this.initPromise) return this.initPromise;
     this.initPromise = this.initializeModel(progressCallback);
     return this.initPromise;


### PR DESCRIPTION
## Summary

- skip local embedding warmup when `embeddingApiUrl` and `embeddingApiKey` are configured
- avoid loading the local `@xenova/transformers` stack for remote embedding setups
- preserve existing behavior for local embedding models

## Why

OpenCode installs plugins with `bun add --ignore-scripts`, which can leave native transitive dependencies unresolved in some environments. For `opencode-mem`, remote embedding mode does not need local transformer warmup, so eagerly warming that path can fail unnecessarily during plugin startup.

This change keeps remote embedding mode on the remote path from the start, which avoids startup failures while leaving local embedding behavior unchanged.