### PR TITLE
fix: allow explicit profile preference writes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -298,7 +298,12 @@ export const OpenCodeMemPlugin: Plugin = async (ctx: PluginInput) => {
                       description: `Search memories via keywords (MATCH USER LANGUAGE: ${langName})`,
                       args: ["query"],
                     },
-                    { command: "profile", description: "View user profile", args: [] },
+                    {
+                      command: "profile",
+                      description:
+                        "View user profile or save an explicit preference (provide content to write)",
+                      args: ["content?"],
+                    },
                     { command: "list", description: "List recent memories", args: ["limit?"] },
                     { command: "forget", description: "Remove memory", args: ["memoryId"] },
                   ],
@@ -339,12 +344,84 @@ export const OpenCodeMemPlugin: Plugin = async (ctx: PluginInput) => {
                   return JSON.stringify({ success: false, error: searchRes.error });
                 return formatSearchResults(args.query, searchRes, args.limit);
 
-              case "profile":
+              case "profile": {
+                if (args.query) {
+                  return JSON.stringify({
+                    success: false,
+                    error:
+                      "query is not valid for profile mode. Use content to write a preference or omit all args to read.",
+                  });
+                }
+
                 const { userProfileManager } =
                   await import("./services/user-profile/user-profile-manager.js");
-                const profile = userProfileManager.getActiveProfile(
-                  tags.user.userEmail || "unknown"
-                );
+
+                const userId = tags.user.userEmail || "unknown";
+
+                // --- WRITE: explicit preference ---
+                if (args.content !== undefined) {
+                  const trimmed = args.content.trim();
+                  if (!trimmed) {
+                    return JSON.stringify({ success: false, error: "content must not be blank" });
+                  }
+
+                  if (!tags.user.userEmail) {
+                    return JSON.stringify({
+                      success: false,
+                      error:
+                        "Cannot save profile preference because no user email could be resolved. Configure userEmailOverride or git user.email.",
+                    });
+                  }
+
+                  if (isFullyPrivate(trimmed)) {
+                    return JSON.stringify({ success: false, error: "Private content blocked" });
+                  }
+
+                  const sanitizedContent = stripPrivateContent(trimmed);
+
+                  const newPreference = {
+                    category: "explicit",
+                    description: sanitizedContent,
+                    confidence: 1.0,
+                    evidence: ["manual-write"],
+                    lastUpdated: Date.now(),
+                  };
+
+                  const existingProfile = userProfileManager.getActiveProfile(userId);
+
+                  if (existingProfile) {
+                    const existingData = JSON.parse(existingProfile.profileData);
+                    const mergedData = userProfileManager.mergeProfileData(existingData, {
+                      preferences: [newPreference],
+                    });
+                    userProfileManager.updateProfile(
+                      existingProfile.id,
+                      mergedData,
+                      0,
+                      `Explicit preference added: ${sanitizedContent.slice(0, 80)}`
+                    );
+                    return JSON.stringify({
+                      success: true,
+                      message: "Preference saved to profile",
+                    });
+                  } else {
+                    userProfileManager.createProfile(
+                      userId,
+                      tags.user.displayName || userId,
+                      tags.user.userName || userId,
+                      tags.user.userEmail || userId,
+                      { preferences: [newPreference], patterns: [], workflows: [] },
+                      0
+                    );
+                    return JSON.stringify({
+                      success: true,
+                      message: "Profile created with preference",
+                    });
+                  }
+                }
+
+                // --- READ: no content provided ---
+                const profile = userProfileManager.getActiveProfile(userId);
                 if (!profile) return JSON.stringify({ success: true, profile: null });
                 const pData = JSON.parse(profile.profileData);
                 return JSON.stringify({
@@ -355,6 +432,7 @@ export const OpenCodeMemPlugin: Plugin = async (ctx: PluginInput) => {
                     lastAnalyzed: profile.lastAnalyzedAt,
                   },
                 });
+              }
 
               case "list":
                 const listRes = await memoryClient.listMemories(tags.project.tag, args.limit || 20);

--- a/src/index.ts
+++ b/src/index.ts
@@ -373,11 +373,13 @@ export const OpenCodeMemPlugin: Plugin = async (ctx: PluginInput) => {
                     });
                   }
 
-                  if (isFullyPrivate(trimmed)) {
+                  const sanitizedContent = stripPrivateContent(trimmed);
+                  const hasNonPrivateContent =
+                    sanitizedContent.replace(/\[REDACTED\]/g, "").trim().length > 0;
+
+                  if (isFullyPrivate(trimmed) || !hasNonPrivateContent) {
                     return JSON.stringify({ success: false, error: "Private content blocked" });
                   }
-
-                  const sanitizedContent = stripPrivateContent(trimmed);
 
                   const newPreference = {
                     category: "explicit",

--- a/tests/profile-tool-runtime.test.ts
+++ b/tests/profile-tool-runtime.test.ts
@@ -1,0 +1,193 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { connectionManager } from "../src/services/sqlite/connection-manager.js";
+
+const WARMUP_KEY = Symbol.for("opencode-mem.plugin.warmedup");
+
+let tmpDir: string;
+
+function writeProjectConfig(config: Record<string, unknown>) {
+  const opencodeDir = join(tmpDir, ".opencode");
+  mkdirSync(opencodeDir, { recursive: true });
+  writeFileSync(join(opencodeDir, "opencode-mem.json"), JSON.stringify(config), "utf-8");
+}
+
+async function createPlugin() {
+  const { memoryClient } = await import("../src/services/client.js");
+  mock.module("../src/services/client.js", async () => ({
+    memoryClient: {
+      ...memoryClient,
+      isReady: async () => true,
+      warmup: async () => {},
+    },
+  }));
+
+  globalThis[WARMUP_KEY as keyof typeof globalThis] = true as any;
+
+  const { OpenCodeMemPlugin } = await import(`../src/index.js?runtime=${Date.now()}`);
+  return OpenCodeMemPlugin({
+    directory: tmpDir,
+    worktree: tmpDir,
+    project: { id: "test-project" } as any,
+    serverUrl: new URL("http://localhost:4096"),
+    client: {
+      path: { get: async () => ({ data: { state: join(tmpDir, "state") } }) },
+      provider: { list: async () => ({ data: { connected: [] } }) },
+      tui: null,
+    } as any,
+    $: (() => {
+      throw new Error("not used in tests");
+    }) as any,
+  });
+}
+
+describe("memory tool profile runtime behavior", () => {
+  beforeAll(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "opencode-mem-runtime-"));
+  });
+
+  beforeEach(() => {
+    const opencodeDir = join(tmpDir, ".opencode");
+    if (existsSync(opencodeDir)) rmSync(opencodeDir, { recursive: true, force: true });
+    mock.restore();
+    delete globalThis[WARMUP_KEY as keyof typeof globalThis];
+
+    const userProfilesDbPath = join(tmpDir, "data", "user-profiles.db");
+    if (existsSync(userProfilesDbPath)) {
+      const db = connectionManager.getConnection(userProfilesDbPath);
+      try {
+        db.run("DELETE FROM user_profile_changelogs");
+        db.run("DELETE FROM user_profiles");
+      } catch {}
+    }
+  });
+
+  afterEach(() => {
+    mock.restore();
+    delete globalThis[WARMUP_KEY as keyof typeof globalThis];
+  });
+
+  afterAll(() => {
+    connectionManager.closeAll();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("rejects query in profile mode", async () => {
+    writeProjectConfig({
+      storagePath: join(tmpDir, "data"),
+      userEmailOverride: "test@example.com",
+      userNameOverride: "Test User",
+      webServerEnabled: false,
+      autoCaptureEnabled: false,
+    });
+
+    const plugin = await createPlugin();
+    const result = JSON.parse(
+      await plugin.tool.memory.execute({ mode: "profile", query: "jira" }, { sessionID: "s1" })
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("query is not valid for profile mode");
+  });
+
+  it("writes a preference when content is provided and returns it on read", async () => {
+    writeProjectConfig({
+      storagePath: join(tmpDir, "data"),
+      userEmailOverride: "test@example.com",
+      userNameOverride: "Test User",
+      webServerEnabled: false,
+      autoCaptureEnabled: false,
+    });
+
+    const plugin = await createPlugin();
+
+    const writeResult = JSON.parse(
+      await plugin.tool.memory.execute(
+        { mode: "profile", content: "Default Jira board is DOPS" },
+        { sessionID: "s2" }
+      )
+    );
+    expect(writeResult.success).toBe(true);
+
+    const readResult = JSON.parse(
+      await plugin.tool.memory.execute({ mode: "profile" }, { sessionID: "s2" })
+    );
+    expect(readResult.success).toBe(true);
+    expect(
+      readResult.profile.preferences.some(
+        (p: any) => p.description === "Default Jira board is DOPS"
+      )
+    ).toBe(true);
+  });
+
+  it("blocks blank content", async () => {
+    writeProjectConfig({
+      storagePath: join(tmpDir, "data"),
+      userEmailOverride: "test@example.com",
+      userNameOverride: "Test User",
+      webServerEnabled: false,
+      autoCaptureEnabled: false,
+    });
+
+    const plugin = await createPlugin();
+    const result = JSON.parse(
+      await plugin.tool.memory.execute({ mode: "profile", content: "   " }, { sessionID: "s3" })
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("content must not be blank");
+  });
+
+  it("blocks fully private content including adjacent redacted blocks", async () => {
+    writeProjectConfig({
+      storagePath: join(tmpDir, "data"),
+      userEmailOverride: "test@example.com",
+      userNameOverride: "Test User",
+      webServerEnabled: false,
+      autoCaptureEnabled: false,
+    });
+
+    const plugin = await createPlugin();
+    const result = JSON.parse(
+      await plugin.tool.memory.execute(
+        {
+          mode: "profile",
+          content: "<private>a</private><private>b</private>",
+        },
+        { sessionID: "s4" }
+      )
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Private content blocked");
+  });
+
+  it("errors when no user email can be resolved", async () => {
+    writeProjectConfig({
+      storagePath: join(tmpDir, "data"),
+      webServerEnabled: false,
+      autoCaptureEnabled: false,
+    });
+
+    mock.module("node:child_process", () => ({
+      execSync: () => {
+        throw new Error("git config unavailable");
+      },
+    }));
+
+    const plugin = await createPlugin();
+    const result = JSON.parse(
+      await plugin.tool.memory.execute(
+        { mode: "profile", content: "Default Jira board is DOPS" },
+        { sessionID: "s5" }
+      )
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain(
+      "Cannot save profile preference because no user email could be resolved"
+    );
+  });
+});

--- a/tests/profile-write.test.ts
+++ b/tests/profile-write.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Tests for explicit user preference writes via UserProfileManager.
+ * Exercises the write path added to src/index.ts `profile` mode
+ * by testing the underlying manager directly (no live plugin context needed).
+ */
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// We patch CONFIG.storagePath before importing the manager so the DB lands in tmp.
+let tmpDir: string;
+
+async function makeManager() {
+  // Dynamic import after setting storagePath so the constructor picks up the temp dir.
+  const { CONFIG } = await import("../src/config.js");
+  CONFIG.storagePath = tmpDir;
+  // Re-import fresh instance by side-stepping module cache with a unique query param trick.
+  // Since bun caches ESM modules we instead instantiate the class directly.
+  const { UserProfileManager } =
+    await import("../src/services/user-profile/user-profile-manager.js");
+  return new UserProfileManager();
+}
+
+describe("UserProfileManager – explicit preference writes", () => {
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "opencode-mem-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("creates a profile with an explicit preference when none exists", async () => {
+    const mgr = await makeManager();
+    const userId = "test@example.com";
+
+    mgr.createProfile(
+      userId,
+      "Test User",
+      "testuser",
+      userId,
+      {
+        preferences: [
+          {
+            category: "explicit",
+            description: "Prefer concise answers",
+            confidence: 1.0,
+            evidence: ["manual-write"],
+            lastUpdated: Date.now(),
+          },
+        ],
+        patterns: [],
+        workflows: [],
+      },
+      0
+    );
+
+    const profile = mgr.getActiveProfile(userId);
+    expect(profile).not.toBeNull();
+    const data = JSON.parse(profile!.profileData);
+    expect(data.preferences).toHaveLength(1);
+    expect(data.preferences[0].description).toBe("Prefer concise answers");
+    expect(data.preferences[0].confidence).toBe(1.0);
+    expect(data.preferences[0].evidence).toContain("manual-write");
+  });
+
+  it("merges a new explicit preference into an existing profile without clobbering other prefs", async () => {
+    const mgr = await makeManager();
+    const userId = "test@example.com";
+
+    // Seed with one AI-learned preference
+    mgr.createProfile(
+      userId,
+      "Test User",
+      "testuser",
+      userId,
+      {
+        preferences: [
+          {
+            category: "style",
+            description: "Uses TypeScript",
+            confidence: 0.8,
+            evidence: ["observed"],
+            lastUpdated: Date.now(),
+          },
+        ],
+        patterns: [],
+        workflows: [],
+      },
+      3
+    );
+
+    const existingProfile = mgr.getActiveProfile(userId)!;
+    const existingData = JSON.parse(existingProfile.profileData);
+
+    const newPref = {
+      category: "explicit",
+      description: "Always use numbered lists",
+      confidence: 1.0,
+      evidence: ["manual-write"],
+      lastUpdated: Date.now(),
+    };
+
+    const merged = mgr.mergeProfileData(existingData, { preferences: [newPref] });
+    mgr.updateProfile(
+      existingProfile.id,
+      merged,
+      0,
+      "Explicit preference added: Always use numbered lists"
+    );
+
+    const updated = mgr.getActiveProfile(userId)!;
+    const updatedData = JSON.parse(updated.profileData);
+
+    expect(updatedData.preferences).toHaveLength(2);
+    const descriptions = updatedData.preferences.map((p: any) => p.description);
+    expect(descriptions).toContain("Uses TypeScript");
+    expect(descriptions).toContain("Always use numbered lists");
+    expect(updated.version).toBe(2);
+  });
+
+  it("deduplicates when the same explicit preference is written twice, boosting confidence", async () => {
+    const mgr = await makeManager();
+    const userId = "test@example.com";
+    const description = "Prefer short answers";
+
+    const pref = {
+      category: "explicit",
+      description,
+      confidence: 1.0,
+      evidence: ["manual-write"],
+      lastUpdated: Date.now(),
+    };
+
+    mgr.createProfile(
+      userId,
+      "Test User",
+      "testuser",
+      userId,
+      {
+        preferences: [pref],
+        patterns: [],
+        workflows: [],
+      },
+      0
+    );
+
+    // Write the same preference again (simulates calling profile+content twice)
+    const p1 = mgr.getActiveProfile(userId)!;
+    const d1 = JSON.parse(p1.profileData);
+    const merged = mgr.mergeProfileData(d1, {
+      preferences: [{ ...pref, lastUpdated: Date.now() }],
+    });
+    mgr.updateProfile(p1.id, merged, 0, "Explicit preference added: Prefer short answers");
+
+    const p2 = mgr.getActiveProfile(userId)!;
+    const d2 = JSON.parse(p2.profileData);
+    // Still only one entry (deduplicated by category+description)
+    expect(d2.preferences.filter((p: any) => p.description === description)).toHaveLength(1);
+    // Confidence capped at 1.0 (bumped by 0.1 but clamped)
+    const conf = d2.preferences.find((p: any) => p.description === description)!.confidence;
+    expect(conf).toBeLessThanOrEqual(1.0);
+    expect(conf).toBeGreaterThan(0.9);
+  });
+
+  it("returns null profile for unknown user (no auto-create on read)", async () => {
+    const mgr = await makeManager();
+    const profile = mgr.getActiveProfile("nobody@example.com");
+    expect(profile).toBeNull();
+  });
+
+  it("changelog entry is recorded on explicit preference write", async () => {
+    const mgr = await makeManager();
+    const userId = "test@example.com";
+    const summary = "Explicit preference added: Use snake_case";
+
+    mgr.createProfile(
+      userId,
+      "Test User",
+      "testuser",
+      userId,
+      {
+        preferences: [],
+        patterns: [],
+        workflows: [],
+      },
+      0
+    );
+
+    const p = mgr.getActiveProfile(userId)!;
+    const d = JSON.parse(p.profileData);
+    const merged = mgr.mergeProfileData(d, {
+      preferences: [
+        {
+          category: "explicit",
+          description: "Use snake_case",
+          confidence: 1.0,
+          evidence: ["manual-write"],
+          lastUpdated: Date.now(),
+        },
+      ],
+    });
+    mgr.updateProfile(p.id, merged, 0, summary);
+
+    const changelogs = mgr.getProfileChangelogs(p.id);
+    const last = changelogs[0];
+    expect(last.changeSummary).toBe(summary);
+    expect(last.changeType).toBe("update");
+  });
+});

--- a/tests/profile-write.test.ts
+++ b/tests/profile-write.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { connectionManager } from "../src/services/sqlite/connection-manager.js";
 
 // We patch CONFIG.storagePath before importing the manager so the DB lands in tmp.
 let tmpDir: string;
@@ -15,8 +16,8 @@ async function makeManager() {
   // Dynamic import after setting storagePath so the constructor picks up the temp dir.
   const { CONFIG } = await import("../src/config.js");
   CONFIG.storagePath = tmpDir;
-  // Re-import fresh instance by side-stepping module cache with a unique query param trick.
-  // Since bun caches ESM modules we instead instantiate the class directly.
+  // Bun may cache the imported module, so this helper does not try to reload it.
+  // Instead, each test creates a new UserProfileManager instance after updating CONFIG.storagePath.
   const { UserProfileManager } =
     await import("../src/services/user-profile/user-profile-manager.js");
   return new UserProfileManager();
@@ -28,6 +29,7 @@ describe("UserProfileManager – explicit preference writes", () => {
   });
 
   afterEach(() => {
+    connectionManager.closeAll();
     rmSync(tmpDir, { recursive: true, force: true });
   });
 


### PR DESCRIPTION
## Summary
- allow `memory` tool `mode: "profile"` to persist explicit user preferences when `content` is provided while preserving the existing read behavior
- validate profile write inputs by rejecting `query`, blocking blank/private content, and avoiding writes when no user email can be resolved
- document the write path in the help text and add targeted tests for profile preference persistence/merge behavior

## Validation
- `bun test tests/profile-write.test.ts`
- `bun run typecheck`