### PR TITLE
fix(sqlite): shim db.transaction(fn) on node:sqlite DatabaseSync

### DIFF
--- a/src/services/sqlite/sqlite-bootstrap.ts
+++ b/src/services/sqlite/sqlite-bootstrap.ts
@@ -62,6 +62,34 @@ export function getDatabase(): DatabaseCtor {
         }
         return this.prepare(sql).run(...params);
       }
+      // bun:sqlite and better-sqlite3 expose `db.transaction(fn)` that returns
+      // a callable wrapping `fn` in BEGIN/COMMIT (auto-ROLLBACK on throw).
+      // `node:sqlite`'s DatabaseSync has no equivalent. Used by
+      // `api-handlers.handleAddMemory` and `services/client.addMemory`, so
+      // POST /api/memories and any auto-capture path crash without it.
+      //
+      // Single-mode semantics only (BEGIN); the `.deferred` / `.immediate` /
+      // `.exclusive` variants from better-sqlite3 are not exercised by this
+      // codebase.
+      transaction<Fn extends (...args: unknown[]) => unknown>(fn: Fn): Fn {
+        const self = this;
+        const wrapped = function (this: unknown, ...args: Parameters<Fn>): ReturnType<Fn> {
+          self.exec("BEGIN");
+          try {
+            const result = fn.apply(this, args) as ReturnType<Fn>;
+            self.exec("COMMIT");
+            return result;
+          } catch (err) {
+            try {
+              self.exec("ROLLBACK");
+            } catch {
+              /* rollback failures after partial state are best-effort */
+            }
+            throw err;
+          }
+        };
+        return wrapped as unknown as Fn;
+      }
     }
     Database = DatabaseSyncCompat as unknown as DatabaseCtor;
     return Database;


### PR DESCRIPTION
Follow-up to #121.

## Summary

`bun:sqlite` and `better-sqlite3` both expose `db.transaction(fn)` which returns a callable that wraps `fn` in `BEGIN`/`COMMIT` (auto-`ROLLBACK` on throw). `node:sqlite`'s `DatabaseSync` has no equivalent.

`handleAddMemory` (`services/api-handlers.ts`) and `client.addMemory` (`services/client.ts`) both use this method to atomically insert a memory row, so under Node:

- `POST /api/memories` crashes with `db.transaction is not a function`
- Any auto-capture path that promotes a candidate memory crashes the same way

Reproduced today on opencode 1.15.10 (anomalyco fork) + Node sidecar:

```bash
$ curl -X POST http://127.0.0.1:4747/api/memories \
    -H 'Content-Type: application/json' \
    -d '{"content": "test", "containerTag": "scope-project-xxx", "type": "fact"}'
{"success":false,"error":"TypeError: db.transaction is not a function"}
```

(After patching the sharp install separately — opencode-mem still ships `@xenova/transformers` which needs sharp's native binary, but that's a pre-existing packaging issue, not in scope here.)

## Fix

Subclass `DatabaseSync` to add a `transaction(fn)` method matching the bun:sqlite / better-sqlite3 signature. Single-mode (`BEGIN`) semantics only — the `.deferred` / `.immediate` / `.exclusive` variants are not exercised by this codebase, can be added in a follow-up if needed.

```ts
transaction<Fn extends (...args: unknown[]) => unknown>(fn: Fn): Fn {
  const self = this;
  const wrapped = function (this: unknown, ...args: Parameters<Fn>): ReturnType<Fn> {
    self.exec("BEGIN");
    try {
      const result = fn.apply(this, args) as ReturnType<Fn>;
      self.exec("COMMIT");
      return result;
    } catch (err) {
      try {
        self.exec("ROLLBACK");
      } catch {
        /* best-effort rollback after partial state */
      }
      throw err;
    }
  };
  return wrapped as unknown as Fn;
}
```

## Why it slipped through #121

My local E2E smoke test exercised CRUD via prepared statements but never called `db.transaction()`. The Bun test suite covers a lot of surface but doesn't reach the bun:sqlite-specific transaction path in a Node-runtime-only context. Today's session log on the live Node sidecar surfaced the gap immediately on the first `POST /api/memories`.

## Verification

- `bun test`: 143 pass / 0 fail (Bun path unchanged)
- `bun run typecheck`: clean
- `bun run build`: clean
- `npx prettier --check`: clean
- Node 26 E2E with commit + rollback paths:
  - Successful tx commits both inserts → `SELECT * FROM m` returns both rows
  - Failing tx throws after one insert → `SELECT` still shows the pre-tx state (rollback worked)
- Local patch applied to the cached v2.15.0 install → `POST /api/memories` now returns `{success:true}` as expected.

## Environment

- macOS 26.3 (Apple Silicon, arm64)
- opencode 1.15.10 CLI / 1.15.13 Desktop (anomalyco fork)
- opencode-mem 2.15.0 (with #121 merged)
- Node 26.0.0 (DatabaseSync stable)