### PR TITLE
fix: Windows shutdown, socket cleanup, and JSON parse resilience for tool calls

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -128,12 +128,14 @@ export const OpenCodeMemPlugin: Plugin = async (ctx: PluginInput) => {
       });
   }
 
+  const cleanupPlugin = async () => {
+    if (webServer) await webServer.stop();
+    if (memoryClient) memoryClient.close();
+  };
+
   const shutdownHandler = async () => {
     try {
-      if (webServer) {
-        await webServer.stop();
-      }
-      memoryClient.close();
+      await cleanupPlugin();
       process.exit(0);
     } catch (error) {
       log("Shutdown error", { error: String(error) });
@@ -143,6 +145,10 @@ export const OpenCodeMemPlugin: Plugin = async (ctx: PluginInput) => {
 
   process.on("SIGINT", shutdownHandler);
   process.on("SIGTERM", shutdownHandler);
+  process.on("exit", () => {
+    if (webServer) webServer.stop().catch(() => {});
+    if (memoryClient) memoryClient.close();
+  });
 
   return {
     "chat.message": async (input, output) => {

--- a/src/services/ai/providers/openai-chat-completion.ts
+++ b/src/services/ai/providers/openai-chat-completion.ts
@@ -70,6 +70,21 @@ function hasNonEmptyChoices(data: unknown): data is ToolCallResponse {
   return true;
 }
 
+function extractFirstJSON(raw: string): string | null {
+  let depth = 0;
+  let start = -1;
+  for (let i = 0; i < raw.length; i++) {
+    if (raw[i] === "{" || raw[i] === "[") {
+      if (depth === 0) start = i;
+      depth++;
+    } else if (raw[i] === "}" || raw[i] === "]") {
+      depth--;
+      if (depth === 0) return raw.slice(start, i + 1);
+    }
+  }
+  return null;
+}
+
 export class OpenAIChatCompletionProvider extends BaseAIProvider {
   private readonly aiSessionManager: AISessionManager;
 
@@ -209,6 +224,7 @@ export class OpenAIChatCompletionProvider extends BaseAIProvider {
     let iterations = 0;
     const maxIterations = this.config.maxIterations ?? 5;
     const iterationTimeout = this.config.iterationTimeout ?? 30000;
+    let lastErrorMessage = "";
 
     while (iterations < maxIterations) {
       iterations++;
@@ -347,7 +363,19 @@ export class OpenAIChatCompletionProvider extends BaseAIProvider {
 
             if (toolCall.function.name === toolSchema.function.name) {
               try {
-                const parsed = JSON.parse(toolCall.function.arguments);
+                const parsed = (() => {
+                  const raw = toolCall.function.arguments;
+                  if (typeof raw !== "string") {
+                    return JSON.parse(JSON.stringify(raw));
+                  }
+                  try {
+                    return JSON.parse(raw);
+                  } catch (e1) {
+                    const fixed = extractFirstJSON(raw);
+                    if (fixed) return JSON.parse(fixed);
+                    throw e1;
+                  }
+                })();
                 const result = UserProfileValidator.validate(parsed);
                 if (!result.valid) {
                   throw new Error(result.errors.join(", "));
@@ -381,6 +409,7 @@ export class OpenAIChatCompletionProvider extends BaseAIProvider {
                 });
 
                 const errorMessage = `Validation failed: ${String(validationError)}`;
+                lastErrorMessage = errorMessage;
                 this.addToolResponse(
                   session.id,
                   messages,
@@ -409,8 +438,9 @@ export class OpenAIChatCompletionProvider extends BaseAIProvider {
         }
 
         const retrySequence = this.aiSessionManager.getLastSequence(session.id) + 1;
-        const retryPrompt =
-          "Please use the save_memories tool to extract and save the memories from the conversation as instructed.";
+        const retryPrompt = lastErrorMessage
+          ? `Your previous attempt failed. Error: ${lastErrorMessage}. Please fix the JSON in your tool call arguments and try again. Output ONLY valid JSON, no extra text outside the JSON structure.`
+          : "Please use the tool to extract and save the data as instructed.";
 
         this.aiSessionManager.addMessage({
           aiSessionId: session.id,

--- a/src/services/web-server.ts
+++ b/src/services/web-server.ts
@@ -85,6 +85,7 @@ function serveFetch(opts: {
       const webRes = await opts.fetch(webReq);
       res.statusCode = webRes.status;
       webRes.headers.forEach((value, name) => res.setHeader(name, value));
+      res.setHeader("Connection", "close");
 
       if (webRes.body) {
         Readable.fromWeb(webRes.body as unknown as Parameters<typeof Readable.fromWeb>[0]).pipe(
@@ -110,12 +111,21 @@ function serveFetch(opts: {
       listenError = err;
     }
   });
-  server.listen(opts.port, opts.hostname);
+  server.listen({ port: opts.port, host: opts.hostname, reuseAddr: true });
+  server.unref();
+  server.timeout = 30000;
+  server.keepAliveTimeout = 10000;
+  server.headersTimeout = 11000;
 
   if (listenError) {
     throw listenError;
   }
-  return { stop: () => server.close() };
+  return {
+    stop: () => {
+      server.closeAllConnections();
+      server.close();
+    },
+  };
 }
 
 const __filename = fileURLToPath(import.meta.url);


### PR DESCRIPTION
### Problem

On Windows, when opencode exits (via `exit` command, SIGTERM, or terminal close),
the web server on port 4747 leaves TCP sockets in CLOSE_WAIT state. These accumulate
over multiple restarts, eventually blocking the port. Additionally, Chrome keep-alive
connections to the web UI accumulate CLOSE_WAIT during normal operation.

### Steps to reproduce

1. Start opencode on Windows
2. `exit` → open a new terminal → `opencode` again
3. `netstat -ano | findstr ":4747"` — port still occupied by old PID
4. Open http://localhost:4747 in Chrome, close the tab, check netstat — CLOSE_WAIT persists

### Root cause

1. `server.close()` stops accepting but doesn't destroy existing connections
2. `beforeExit` doesn't fire on `process.exit()` (how opencode exits on Windows)
3. No `SO_REUSEADDR` → TIME_WAIT blocks port rebinding
4. Chrome keep-alive keeps half-closed sockets in CLOSE_WAIT

### Fix

- `closeAllConnections()` + `close()` — destroy all sockets on shutdown
- `reuseAddr: true` — penetrate OS TCP TIME_WAIT for immediate rebinding
- `server.timeout` / `keepAliveTimeout` / `headersTimeout` — auto-destroy idle connections
- `Connection: close` header — prevent Chrome keep-alive CLOSE_WAIT
- `process.on('exit')` replaces `beforeExit` — fires on all exit paths
- `cleanupPlugin()` — shared cleanup for SIGINT/SIGTERM/exit paths

### Problem (User Profile Learning)

User profile learning fails with `JSON Parse error` when `deepseek-v4-flash`
generates malformed tool call arguments. Three failure modes were observed:

1. Extra text appended after valid JSON — model adds Chinese commentary or
   additional JSON objects after the closing `}` (e.g. `{"preferences":[...]}` 还有一些补充)
2. JavaScript expressions in JSON — model writes `Date.now()` instead of a
   numeric timestamp inside preference objects
3. Truncated/overly-long JSON — model output exceeds available context

These failures were silent — the retry mechanism sent a generic "please use
the tool" message back to the model instead of the specific parse error,
making self-correction nearly impossible.

### Steps to reproduce

1. Configure opencode-mem with `memoryProvider` using `deepseek-v4-flash`
2. Wait for 10+ prompts to accumulate and idle to trigger profile learning
3. Check log: `OpenAI tool response validation failed: SyntaxError: JSON Parse error`
4. Observe that `iteration` never reaches 2 — retry never succeeds

### Root cause

- `JSON.parse()` has no fallback for model-generated noise after valid JSON
- Retry error message is hardcoded as "Please use the save_memories tool..."
  instead of relaying the actual parse failure to the model

### Fix (User Profile Learning)

- `extractFirstJSON()` — bracket-matching extraction that salvages the first
  complete JSON object from contaminated tool call arguments
- Retry prompt now includes the specific `SyntaxError` message (e.g.
  "Unexpected token '还' at position 582") instead of a generic instruction
- Both fixes apply to all tool call paths (auto-capture, profile learning,
  and future features) without architectural changes