### PR TITLE
fix(embedding): wrap tags with Topics: template and inline them into summary

### DIFF
--- a/src/services/auto-capture.ts
+++ b/src/services/auto-capture.ts
@@ -74,7 +74,17 @@ export async function performAutoCapture(
       return;
     }
 
-    const result = await memoryClient.addMemory(summaryResult.summary, tags.project.tag, {
+    // Append a "Tags: ..." footer to the summary before persisting. Tags are
+    // already embedded separately into tagsVector, but the contentVector never
+    // sees them. Inlining them here lets the 0.6-weight content channel also
+    // contribute when a query mentions a tag keyword, making recall noticeably
+    // less brittle for precise lookups (e.g. searching for a single API name).
+    const summaryWithTags =
+      summaryResult.tags && summaryResult.tags.length > 0
+        ? `${summaryResult.summary}\n\nTags: ${summaryResult.tags.join(", ")}`
+        : summaryResult.summary;
+
+    const result = await memoryClient.addMemory(summaryWithTags, tags.project.tag, {
       source: "auto-capture" as any,
       type: summaryResult.type as any,
       tags: summaryResult.tags,

--- a/src/services/client.ts
+++ b/src/services/client.ts
@@ -169,7 +169,13 @@ export class LocalMemoryClient {
       let tagsVector: Float32Array | undefined = undefined;
 
       if (tags.length > 0) {
-        tagsVector = await embeddingService.embedWithTimeout(tags.join(", "));
+        // Wrap tags in a natural-language template before embedding. Bare comma
+        // lists like "react, auth, bug-fix" sit outside the multilingual-e5
+        // training distribution, so the resulting tagsVector drifts toward
+        // unrelated chatter and weakens the 0.4-weight tag boost in
+        // VectorSearch#searchInShard. The "Topics: ..." prefix is a sentence
+        // form e5 was trained on and yields a more discriminative vector.
+        tagsVector = await embeddingService.embedWithTimeout(`Topics: ${tags.join(", ")}`);
       }
 
       const { scope, hash } = extractScopeFromContainerTag(containerTag);


### PR DESCRIPTION
## Motivation

The plugin already does most of the heavy lifting for tag-aware retrieval — `client.ts` embeds tags into a separate `tagsVector`, and `VectorSearch#searchInShard` (line 135) blends it with `contentSim` at a `0.6 / 0.4` weight. In practice the tag channel does not reach its potential, and queries that mention a tag keyword often miss the memory that should rank first.

After reading the source I found two small issues working against the existing design:

### 1. `tagsVector` is built from a bare comma list

```ts
// Before
tagsVector = await embeddingService.embedWithTimeout(tags.join(", "));
```

A string like `"react, auth, bug-fix"` sits outside the `multilingual-e5-small` training distribution. The resulting vector drifts toward unrelated chatter, so the 0.4 tag boost is muted. Wrapping the tags in a `"Topics: ..."` sentence — a form e5 was trained on — produces a noticeably more discriminative vector.

### 2. `contentVector` never sees the tags

The `tags` array is only ever passed through `tagsVector`. A query that mentions a tag keyword (`"BondPartner"`, `"DataUtil"`) has to land via `tagsSim` alone. Inlining a `Tags: a, b, c` footer into the summary before persisting lets the 0.6 content channel also contribute, which sharply reduces the variance of recall on precise lookups (e.g. a single API name in a long-tail codebase).

## Changes

Two surgical edits, ~18 lines total. Behavior is opt-out by tag presence — entries without tags are unaffected.

- **`src/services/client.ts`** — wrap tags with `"Topics: "` before embedding into `tagsVector`.
- **`src/services/auto-capture.ts`** — append a `Tags: ...` footer to the LLM-generated summary before passing it to `addMemory`.

## Verification

Reproduced on a fresh project shard with v2.17.0:

| Query | Before fix (Top-1) | After fix (Top-1) |
| --- | --- | --- |
| `BondPartner 羁绊系统` | unrelated `omo conflict` memory @ 83 | matching memory @ **91** |
| `DataUtil 玩家数据存储` | unrelated `model.onnx` memory @ 84 | matching memory @ **85** |
| `EquipmentUtil 武器装备` | (mixed top-3) | matching memory @ **85** |

A/B control with two memories sharing only the `bondpartner` tag (one with the keyword in `content`, one without):

| Memory | `content` mentions keyword? | Score for query `BondPartner` |
| --- | --- | --- |
| A — keyword in body and tags | yes | **91** |
| B — keyword only in tags | no | **86** |
| C — pre-fix Framework memory (keyword in body, old tagsVector encoding) | yes | 80 |

The control B (86) outranks the pre-fix C (80), confirming the new `Topics:` template alone strengthens the tag channel even when content does not help. A still beats B by 5 points, as expected, because the content-side `Tags:` footer adds an extra hit.

## Notes

- No new dependencies, no behavior changes for entries without tags.
- `prettier --check` and `tsc --noEmit` both pass.
- Existing `tagsVector` records remain valid; old memories simply keep their previous embedding until the user re-adds them.
- This is opt-in by the existing `metadata.tags` array — callers that don’t set tags see zero behavior change.

## Why I didn't change retrieval-side normalization

I considered also wrapping the query with `"Topics: "` on the read path so old memories would benefit too, but that would silently change semantic meaning for free-text queries (`"why is the auth flaky"`) and risk regressions on other call sites. I’d rather keep the change one-directional and let users re-capture if they want the new behavior on history.