### PR TITLE
fix(auto-capture): release captured=2 lock on abort to prevent stuck prompts

### DIFF
--- a/src/services/auto-capture.ts
+++ b/src/services/auto-capture.ts
@@ -21,6 +21,13 @@ export async function performAutoCapture(
 ): Promise<void> {
   if (isCaptureRunning) return;
   isCaptureRunning = true;
+  // Tracks the prompt currently held in the captured=2 in-progress state.
+  // Any code path between claimPrompt() and a terminal action (markAsCaptured
+  // or deletePrompt) MUST leave this set so the finally block can release the
+  // lock. Without this, transient failures (no AI response yet, missing
+  // client, LLM error, plugin restart) leave the row stuck at captured=2 and
+  // block all future captures of that prompt.
+  let claimedPromptId: string | null = null;
   try {
     const prompt = userPromptManager.getLastUncapturedPrompt(sessionID);
     if (!prompt) {
@@ -30,6 +37,7 @@ export async function performAutoCapture(
     if (!userPromptManager.claimPrompt(prompt.id)) {
       return;
     }
+    claimedPromptId = prompt.id;
 
     if (!ctx.client) {
       throw new Error("Client not available");
@@ -71,6 +79,7 @@ export async function performAutoCapture(
 
     if (!summaryResult || summaryResult.type === "skip") {
       userPromptManager.deletePrompt(prompt.id);
+      claimedPromptId = null;
       return;
     }
 
@@ -92,6 +101,7 @@ export async function performAutoCapture(
     if (result.success) {
       userPromptManager.linkMemoryToPrompt(prompt.id, result.id);
       userPromptManager.markAsCaptured(prompt.id);
+      claimedPromptId = null;
 
       if (CONFIG.showAutoCaptureToasts) {
         await ctx.client?.tui
@@ -107,6 +117,22 @@ export async function performAutoCapture(
       }
     }
   } finally {
+    // Release any in-progress claim that did not reach a terminal state.
+    // This covers both early returns (no AI response yet, missing client,
+    // empty content) and exceptions (LLM failure, network error). Without
+    // releasing here, the prompt would remain locked at captured=2 with no
+    // automatic recovery path until the next plugin restart.
+    if (claimedPromptId !== null) {
+      try {
+        userPromptManager.releaseClaim(claimedPromptId);
+      } catch (releaseErr) {
+        log(
+          `Failed to release captured=2 claim for prompt ${claimedPromptId}: ${
+            releaseErr instanceof Error ? releaseErr.message : String(releaseErr)
+          }`
+        );
+      }
+    }
     isCaptureRunning = false;
   }
 }

--- a/src/services/user-prompt/user-prompt-manager.ts
+++ b/src/services/user-prompt/user-prompt-manager.ts
@@ -108,6 +108,23 @@ export class UserPromptManager {
     return result.changes > 0;
   }
 
+  /**
+   * Release a previously claimed prompt back to the pending state so it can
+   * be retried by a future capture cycle. Used when capture aborts before
+   * either successfully writing a memory or explicitly skipping the prompt
+   * (e.g. transient network error, missing AI response, plugin restart).
+   *
+   * Only rows still marked as in-progress (captured = 2) are touched, so
+   * concurrent callers that already finished the capture cannot be reverted.
+   */
+  releaseClaim(promptId: string): boolean {
+    const stmt = this.db.prepare(
+      `UPDATE user_prompts SET captured = 0 WHERE id = ? AND captured = 2`
+    );
+    const result = stmt.run(promptId);
+    return result.changes > 0;
+  }
+
   countUncapturedPrompts(): number {
     const stmt = this.db.prepare(`SELECT COUNT(*) as count FROM user_prompts WHERE captured = 0`);
     const row = stmt.get() as any;

--- a/tests/user-prompt-manager-claim.test.ts
+++ b/tests/user-prompt-manager-claim.test.ts
@@ -1,0 +1,117 @@
+import { afterAll, beforeEach, afterEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Redirect home to a temporary directory BEFORE importing config so that
+// CONFIG.storagePath resolves under the test sandbox.
+const sandbox = mkdtempSync(join(tmpdir(), "opencode-mem-claim-home-"));
+const originalHome = process.env.HOME;
+const originalUserProfile = process.env.USERPROFILE;
+process.env.HOME = sandbox;
+process.env.USERPROFILE = sandbox;
+
+const { UserPromptManager } = await import("../src/services/user-prompt/user-prompt-manager.js");
+
+afterAll(() => {
+  process.env.HOME = originalHome;
+  process.env.USERPROFILE = originalUserProfile;
+  // Best-effort cleanup. On Windows the SQLite connection may still hold a
+  // lock on the WAL file even after the process is shutting down, which can
+  // surface as EBUSY. Failing here would mask test results, so we swallow.
+  try {
+    rmSync(sandbox, { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
+});
+
+describe("UserPromptManager.claimPrompt / releaseClaim", () => {
+  let mgr: InstanceType<typeof UserPromptManager>;
+  let activeIds: string[];
+
+  beforeEach(() => {
+    mgr = new UserPromptManager();
+    activeIds = [];
+  });
+
+  afterEach(() => {
+    // Clean up rows the test inserted so subsequent tests start with an
+    // empty table.
+    for (const id of activeIds) {
+      try {
+        mgr.deletePrompt(id);
+      } catch {
+        // ignore
+      }
+    }
+  });
+
+  function getRawCaptured(id: string): number {
+    const raw = (
+      mgr as unknown as {
+        db: { prepare: (s: string) => { get: (a: string) => { captured: number } | undefined } };
+      }
+    ).db
+      .prepare(`SELECT captured FROM user_prompts WHERE id = ?`)
+      .get(id);
+    return raw?.captured ?? -1;
+  }
+
+  function newPrompt(sessionId = "session-test", content = "hello") {
+    const id = mgr.savePrompt(
+      sessionId,
+      `msg-${Date.now()}-${Math.random()}`,
+      "/tmp/proj",
+      content
+    );
+    activeIds.push(id);
+    return id;
+  }
+
+  it("claimPrompt transitions captured 0 → 2 and returns true", () => {
+    const id = newPrompt();
+    expect(mgr.claimPrompt(id)).toBe(true);
+    expect(getRawCaptured(id)).toBe(2);
+  });
+
+  it("claimPrompt returns false when the row is already claimed", () => {
+    const id = newPrompt();
+    expect(mgr.claimPrompt(id)).toBe(true);
+    expect(mgr.claimPrompt(id)).toBe(false);
+  });
+
+  it("releaseClaim transitions captured 2 → 0 and exposes the row to retry", () => {
+    const id = newPrompt("session-release");
+    expect(mgr.claimPrompt(id)).toBe(true);
+    expect(mgr.releaseClaim(id)).toBe(true);
+    expect(getRawCaptured(id)).toBe(0);
+
+    const next = mgr.getLastUncapturedPrompt("session-release");
+    expect(next).not.toBeNull();
+    expect(next!.id).toBe(id);
+  });
+
+  it("releaseClaim is a no-op when the row is already captured=1", () => {
+    const id = newPrompt();
+    mgr.claimPrompt(id);
+    mgr.markAsCaptured(id);
+
+    expect(mgr.releaseClaim(id)).toBe(false);
+    expect(getRawCaptured(id)).toBe(1);
+  });
+
+  it("releaseClaim is a no-op when the row was never claimed", () => {
+    const id = newPrompt();
+    expect(mgr.releaseClaim(id)).toBe(false);
+    expect(getRawCaptured(id)).toBe(0);
+  });
+
+  it("supports a full claim → release → re-claim retry cycle", () => {
+    const id = newPrompt();
+    expect(mgr.claimPrompt(id)).toBe(true);
+    expect(mgr.releaseClaim(id)).toBe(true);
+    expect(mgr.claimPrompt(id)).toBe(true);
+    expect(getRawCaptured(id)).toBe(2);
+  });
+});


### PR DESCRIPTION
## Problem

When `performAutoCapture` claims a prompt by transitioning its `captured` column from `0` to `2`, only **two** paths actually clean that lock up:

- `summaryResult.type === "skip"` → `deletePrompt`
- `result.success === true` → `markAsCaptured`

Every other early return or thrown exception leaves the row pinned at `captured = 2` with no recovery path:

- `!response.data` (transient session API miss)
- `promptIndex === -1` (assistant has not yet responded)
- `aiMessages.length === 0`
- `textResponses.length === 0 && toolCalls.length === 0`
- `generateSummary` throwing (LLM timeout, network failure, structured-output validation error)
- `memoryClient.addMemory` throwing
- Plugin restart while the LLM call is in flight

The startup `UPDATE captured = 0 WHERE captured = 2` only resets the lock; it does **not** retry the affected prompt because `getLastUncapturedPrompt` returns the **latest** uncaptured prompt for the **current** session, so old released prompts from prior sessions stay un-captured forever.

In practice this means a single transient failure permanently loses the conversation summary for that prompt, and the problem accumulates across restarts as more prompts are silently dropped. I hit this on Windows with multiple stuck `captured=2` rows across two sessions and one `captured=0` orphan that the startup reset had freed but no future capture pass would ever pick up.

## Fix

Introduce `releaseClaim` on `UserPromptManager` that conditionally moves rows from `captured = 2` back to `captured = 0` (no-op if already `0` or `1`, so a successful capture cannot be rolled back).

In `performAutoCapture`, track the currently claimed prompt id in a local variable, clear it on the two terminal paths, and release the claim from the existing `finally` block on every other exit path. The release call itself is wrapped in `try/catch` so database errors during cleanup get logged but never mask the original capture failure.

This guarantees:

1. Every successful claim is followed by exactly one terminal action (`markAsCaptured`, `deletePrompt`, or `releaseClaim`).
2. Transient failures leave the row in `captured = 0` so the next `session.idle` cycle naturally retries it.
3. The existing `isCaptureRunning` flag still serializes captures within a process.

## Tests

New `tests/user-prompt-manager-claim.test.ts`:

- Claim transitions `captured 0 → 2` and is mutually exclusive (concurrent claim returns false).
- Release transitions `captured 2 → 0` and re-exposes the prompt to `getLastUncapturedPrompt`.
- Release is a no-op for `captured = 1` (success) and `captured = 0` (already pending) so a successful capture is never rolled back by a stale release.
- Full `claim → release → re-claim` retry cycle works end-to-end.

```text
$ bun test tests/user-prompt-manager-claim.test.ts
 6 pass
 0 fail
 17 expect() calls
```

`tsc --noEmit` and `prettier --check` pass on all changed files. Pre-existing unrelated failures on `upstream/main` (project-scope, plugin-loader contract, vector backends, user-profile manager) are unchanged by this PR — verified by stashing the diff and re-running the same test files on the baseline.

## Risk

Low. The release SQL is guarded with `WHERE captured = 2`, so it cannot race against `markAsCaptured` (`captured = 1`) or another claim. The only behavior change for existing users is that previously stuck rows now self-heal on the next idle cycle instead of waiting for a process restart.

## Out of scope (follow-up ideas)

- `getLastUncapturedPrompt` only looks at the current session, so prompts from terminated sessions whose captures were aborted remain un-captured even after this fix releases the lock. A future PR could add a stale-claim sweep at startup that retries old `captured = 0` rows from any session, or change `performAutoCapture` to optionally process older pending rows.
- Add a TTL on `captured = 2` so an attacker / bug that wedges a row mid-flight cannot keep blocking future captures forever; this fix removes the most common cause but does not add a hard timeout.
