### PR TITLE
fix(sqlite): spread single-array params in node:sqlite run() shim

### DIFF
--- a/src/services/sqlite/sqlite-bootstrap.ts
+++ b/src/services/sqlite/sqlite-bootstrap.ts
@@ -60,6 +60,14 @@ export function getDatabase(): DatabaseCtor {
         if (params.length === 0) {
           return this.exec(sql);
         }
+        // bun:sqlite and better-sqlite3 accept a single array of bind values
+        // (`db.run(sql, [a, b])`); node:sqlite's DatabaseSync treats an array as
+        // a named-parameters object and throws `Unknown named parameter '0'`.
+        // Spread it so positional `?` placeholders bind correctly. Callers such
+        // as services/ai/session/ai-session-manager.ts use this array form.
+        if (params.length === 1 && Array.isArray(params[0])) {
+          return this.prepare(sql).run(...(params[0] as unknown[]));
+        }
         return this.prepare(sql).run(...params);
       }
       // bun:sqlite and better-sqlite3 expose `db.transaction(fn)` that returns

--- a/tests/sqlite-bootstrap-array-params.test.ts
+++ b/tests/sqlite-bootstrap-array-params.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "bun:test";
+import { getDatabase } from "../src/services/sqlite/sqlite-bootstrap.js";
+
+/**
+ * Regression for `Unknown named parameter '0'`.
+ *
+ * `db.run(sql, [a, b])` — passing a single array of bind values — is valid
+ * better-sqlite3 / bun:sqlite usage and is used by
+ * services/ai/session/ai-session-manager.ts (e.g. `cleanupExpiredSessions`,
+ * `addMessage`, `deleteSession`, `clearMessages`).
+ *
+ * Under Node, getDatabase() resolves to the `DatabaseSyncCompat` wrapper around
+ * node:sqlite. Its `run(sql, ...params)` forwarded `this.prepare(sql).run(...params)`,
+ * so a single array argument reached the statement as one object value;
+ * node:sqlite then read its indices ("0", "1", …) as named parameters and threw
+ * `Unknown named parameter '0'`. opencode 1.15.x loads plugins under Node, so the
+ * auto-capture path crashed there while passing under Bun.
+ *
+ * Note on runtime: under `bun test` getDatabase() returns bun:sqlite, which accepts
+ * arrays natively — so this asserts runtime parity. Run under Node (node:sqlite) to
+ * reproduce/guard the original regression.
+ */
+describe("sqlite-bootstrap: db.run with a single array of params", () => {
+  function freshDb() {
+    const Database = getDatabase() as unknown as new (filename?: string) => {
+      exec(sql: string): unknown;
+      run(sql: string, ...params: unknown[]): unknown;
+      prepare(sql: string): { get(...params: unknown[]): any; all(...params: unknown[]): any[] };
+    };
+    const db = new Database(":memory:");
+    db.exec("CREATE TABLE t (id INTEGER PRIMARY KEY, v INTEGER, label TEXT)");
+    return db;
+  }
+
+  it("binds a single-element array positionally", () => {
+    const db = freshDb();
+    db.run("INSERT INTO t (v) VALUES (?)", [42]);
+    const row = db.prepare("SELECT v FROM t").get();
+    expect(row.v).toBe(42);
+  });
+
+  it("binds a multi-element array positionally", () => {
+    const db = freshDb();
+    db.run("INSERT INTO t (v, label) VALUES (?, ?)", [7, "seven"]);
+    const row = db.prepare("SELECT v, label FROM t").get();
+    expect(row.v).toBe(7);
+    expect(row.label).toBe("seven");
+  });
+
+  it("still supports spread positional params", () => {
+    const db = freshDb();
+    db.run("INSERT INTO t (v, label) VALUES (?, ?)", 9, "nine");
+    const row = db.prepare("SELECT v, label FROM t").get();
+    expect(row.v).toBe(9);
+    expect(row.label).toBe("nine");
+  });
+
+  it("still execs paramless statements", () => {
+    const db = freshDb();
+    db.run("INSERT INTO t (v) VALUES (1)");
+    const row = db.prepare("SELECT COUNT(*) AS n FROM t").get();
+    expect(row.n).toBe(1);
+  });
+});


### PR DESCRIPTION
## Problem
Under Node (`node:sqlite`), `db.run(sql, [a, b])` — a single array of bind values — throws `Unknown named parameter '0'`. opencode 1.15.x loads plugins under Node, so this fires in the `session.idle` → `performAutoCapture` path and is swallowed as `Idle processing error: Unknown named parameter '0'` — **auto-capture never persists a memory**. The manual `memory` tool and `POST /api/memories` are unaffected (they use the prepared-statement positional path).

## Root cause
`DatabaseSyncCompat.run()` in `src/services/sqlite/sqlite-bootstrap.ts` forwarded `this.prepare(sql).run(...params)`, so a single array argument reached node:sqlite's `StatementSync` as one object value; node:sqlite reads its indices (`"0"`, `"1"`, …) as **named** parameters. `bun:sqlite` and `better-sqlite3` accept arrays natively, and CI runs Bun and skips the test suite — so it went unnoticed.

Callers using the array form: `src/services/ai/session/ai-session-manager.ts` — `cleanupExpiredSessions`, `deleteSession`, `addMessage`, `clearMessages`, `updateSession`.

## Reproduction (Node 26, node:sqlite)
```js
db.run("INSERT INTO t (v) VALUES (?)", [42]);
// before: ✗ Unknown named parameter '0'
// after:  ✓ inserts v=42
```

## Fix
Spread a single array argument in the shim's `run()` so positional `?` placeholders bind correctly — matching the `better-sqlite3`/`bun:sqlite` semantics the shim already emulates. One change covers all current and future `db.run(sql, [array])` callers.

## Test
`tests/sqlite-bootstrap-array-params.test.ts`. Note: under `bun test`, `getDatabase()` returns `bun:sqlite` (arrays already work), so it asserts parity — run under **Node** to reproduce/guard the original regression.
