### PR TITLE
[134] Fix auto capture silent fails

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -38,6 +38,7 @@ interface OpenCodeMemConfig {
   autoCaptureEnabled?: boolean;
   autoCaptureMaxIterations?: number;
   autoCaptureIterationTimeout?: number;
+  autoCaptureMaxRetries?: number;
   autoCaptureLanguage?: string;
   memoryProvider?: "openai-chat" | "openai-responses" | "anthropic";
   memoryModel?: string;
@@ -126,6 +127,7 @@ const DEFAULTS: Required<
   autoCaptureEnabled: true,
   autoCaptureMaxIterations: 5,
   autoCaptureIterationTimeout: 30000,
+  autoCaptureMaxRetries: 3,
   vectorBackend: "usearch-first",
   aiSessionRetentionDays: 7,
   webServerEnabled: true,
@@ -346,6 +348,9 @@ const CONFIG_TEMPLATE = `{
    
   // Timeout per iteration in milliseconds (30 seconds default)
   "autoCaptureIterationTimeout": 30000,
+
+  // Maximum number of times to retry capturing a prompt if it fails (due to network, API errors, etc.)
+  "autoCaptureMaxRetries": 3,
    
   // Days to keep AI session history before cleanup
   "aiSessionRetentionDays": 7,
@@ -508,6 +513,7 @@ function buildConfig(fileConfig: OpenCodeMemConfig) {
       fileConfig.autoCaptureMaxIterations ?? DEFAULTS.autoCaptureMaxIterations,
     autoCaptureIterationTimeout:
       fileConfig.autoCaptureIterationTimeout ?? DEFAULTS.autoCaptureIterationTimeout,
+    autoCaptureMaxRetries: fileConfig.autoCaptureMaxRetries ?? DEFAULTS.autoCaptureMaxRetries,
     autoCaptureLanguage: fileConfig.autoCaptureLanguage,
     memoryProvider: (fileConfig.memoryProvider ?? "openai-chat") as
       | "openai-chat"

--- a/src/services/auto-capture.ts
+++ b/src/services/auto-capture.ts
@@ -37,6 +37,7 @@ export async function performAutoCapture(
       return;
     }
     claimedPromptId = prompt.id;
+    attempt = prompt.capture_attempts || 0;
 
     while (attempt < maxRetries) {
       attempt++;

--- a/src/services/auto-capture.ts
+++ b/src/services/auto-capture.ts
@@ -126,6 +126,7 @@ export async function performAutoCapture(
           .catch(() => {});
       }
     } else {
+      log("Auto-capture failed to save memory to database", { error: result.error });
       if (CONFIG.showErrorToasts) {
         await ctx.client?.tui
           .showToast({
@@ -140,8 +141,9 @@ export async function performAutoCapture(
       }
     }
   } catch (error) {
+    const errMsg = error instanceof Error ? error.message : String(error);
+    log("Auto-capture execution error", { error: errMsg });
     if (CONFIG.showErrorToasts) {
-      const errMsg = error instanceof Error ? error.message : String(error);
       const shortReason = errMsg.length > 100 ? errMsg.substring(0, 100) + "..." : errMsg;
       await ctx.client?.tui
         .showToast({

--- a/src/services/auto-capture.ts
+++ b/src/services/auto-capture.ts
@@ -21,13 +21,11 @@ export async function performAutoCapture(
 ): Promise<void> {
   if (isCaptureRunning) return;
   isCaptureRunning = true;
-  // Tracks the prompt currently held in the captured=2 in-progress state.
-  // Any code path between claimPrompt() and a terminal action (markAsCaptured
-  // or deletePrompt) MUST leave this set so the finally block can release the
-  // lock. Without this, transient failures (no AI response yet, missing
-  // client, LLM error, plugin restart) leave the row stuck at captured=2 and
-  // block all future captures of that prompt.
+
   let claimedPromptId: string | null = null;
+  const maxRetries = CONFIG.autoCaptureMaxRetries ?? 3;
+  let attempt = 0;
+
   try {
     const prompt = userPromptManager.getLastUncapturedPrompt(sessionID);
     if (!prompt) {
@@ -39,110 +37,109 @@ export async function performAutoCapture(
     }
     claimedPromptId = prompt.id;
 
-    if (!ctx.client) {
-      throw new Error("Client not available");
-    }
+    while (attempt < maxRetries) {
+      attempt++;
+      try {
+        if (!ctx.client) {
+          throw new Error("Client not available");
+        }
 
-    const response = await ctx.client.session.messages({
-      path: { id: sessionID },
-    });
+        const response = await ctx.client.session.messages({
+          path: { id: sessionID },
+        });
 
-    if (!response.data) {
-      return;
-    }
+        if (!response.data) {
+          return;
+        }
 
-    const messages = response.data;
+        const messages = response.data;
+        const promptIndex = messages.findIndex((m: any) => m.info?.id === prompt.messageId);
+        if (promptIndex === -1) {
+          return;
+        }
 
-    const promptIndex = messages.findIndex((m: any) => m.info?.id === prompt.messageId);
-    if (promptIndex === -1) {
-      return;
-    }
+        const aiMessages = messages.slice(promptIndex + 1);
+        if (aiMessages.length === 0) {
+          return;
+        }
 
-    const aiMessages = messages.slice(promptIndex + 1);
+        const { textResponses, toolCalls } = extractAIContent(aiMessages);
+        if (textResponses.length === 0 && toolCalls.length === 0) {
+          return;
+        }
 
-    if (aiMessages.length === 0) {
-      return;
-    }
+        const tags = getTags(directory);
+        const latestMemory = await getLatestProjectMemory(tags.project.tag);
+        const context = buildMarkdownContext(
+          prompt.content,
+          textResponses,
+          toolCalls,
+          latestMemory
+        );
 
-    const { textResponses, toolCalls } = extractAIContent(aiMessages);
+        const summaryResult = await generateSummary(context, sessionID, prompt.content);
 
-    if (textResponses.length === 0 && toolCalls.length === 0) {
-      return;
-    }
+        if (!summaryResult || summaryResult.type === "skip") {
+          userPromptManager.deletePrompt(prompt.id);
+          claimedPromptId = null;
+          return;
+        }
 
-    const tags = getTags(directory);
-    const latestMemory = await getLatestProjectMemory(tags.project.tag);
+        const summaryWithTags =
+          summaryResult.tags && summaryResult.tags.length > 0
+            ? `${summaryResult.summary}\n\nTags: ${summaryResult.tags.join(", ")}`
+            : summaryResult.summary;
 
-    const context = buildMarkdownContext(prompt.content, textResponses, toolCalls, latestMemory);
+        const result = await memoryClient.addMemory(summaryWithTags, tags.project.tag, {
+          source: "auto-capture" as any,
+          type: summaryResult.type as any,
+          tags: summaryResult.tags,
+          sessionID,
+          promptId: prompt.id,
+          captureTimestamp: Date.now(),
+          displayName: tags.project.displayName,
+          userName: tags.project.userName,
+          userEmail: tags.project.userEmail,
+          projectPath: tags.project.projectPath,
+          projectName: tags.project.projectName,
+          gitRepoUrl: tags.project.gitRepoUrl,
+        });
 
-    const summaryResult = await generateSummary(context, sessionID, prompt.content);
+        if (result.success) {
+          userPromptManager.linkMemoryToPrompt(prompt.id, result.id);
+          userPromptManager.markAsCaptured(prompt.id);
+          claimedPromptId = null;
 
-    if (!summaryResult || summaryResult.type === "skip") {
-      userPromptManager.deletePrompt(prompt.id);
-      claimedPromptId = null;
-      return;
-    }
+          if (CONFIG.showAutoCaptureToasts) {
+            await ctx.client?.tui
+              .showToast({
+                body: {
+                  title: "Memory Captured",
+                  message: "Project memory saved from conversation",
+                  variant: "success",
+                  duration: 3000,
+                },
+              })
+              .catch(() => {});
+          }
+          return;
+        } else {
+          throw new Error(result.error || "Database persistence failed");
+        }
+      } catch (error) {
+        const errMsg = error instanceof Error ? error.message : String(error);
 
-    // Append a "Tags: ..." footer to the summary before persisting. Tags are
-    // already embedded separately into tagsVector, but the contentVector never
-    // sees them. Inlining them here lets the 0.6-weight content channel also
-    // contribute when a query mentions a tag keyword, making recall noticeably
-    // less brittle for precise lookups (e.g. searching for a single API name).
-    const summaryWithTags =
-      summaryResult.tags && summaryResult.tags.length > 0
-        ? `${summaryResult.summary}\n\nTags: ${summaryResult.tags.join(", ")}`
-        : summaryResult.summary;
-
-    const result = await memoryClient.addMemory(summaryWithTags, tags.project.tag, {
-      source: "auto-capture" as any,
-      type: summaryResult.type as any,
-      tags: summaryResult.tags,
-      sessionID,
-      promptId: prompt.id,
-      captureTimestamp: Date.now(),
-      displayName: tags.project.displayName,
-      userName: tags.project.userName,
-      userEmail: tags.project.userEmail,
-      projectPath: tags.project.projectPath,
-      projectName: tags.project.projectName,
-      gitRepoUrl: tags.project.gitRepoUrl,
-    });
-
-    if (result.success) {
-      userPromptManager.linkMemoryToPrompt(prompt.id, result.id);
-      userPromptManager.markAsCaptured(prompt.id);
-      claimedPromptId = null;
-
-      if (CONFIG.showAutoCaptureToasts) {
-        await ctx.client?.tui
-          .showToast({
-            body: {
-              title: "Memory Captured",
-              message: "Project memory saved from conversation",
-              variant: "success",
-              duration: 3000,
-            },
-          })
-          .catch(() => {});
-      }
-    } else {
-      log("Auto-capture failed to save memory to database", { error: result.error });
-      if (CONFIG.showErrorToasts) {
-        await ctx.client?.tui
-          .showToast({
-            body: {
-              title: "Auto Capture Failed",
-              message: "Memory save failed: " + (result.error || "Unknown error"),
-              variant: "error",
-              duration: 5000,
-            },
-          })
-          .catch(() => {});
+        if (attempt < maxRetries) {
+          log(`Auto-capture warning (attempt ${attempt}/${maxRetries})`, { error: errMsg });
+          await new Promise((resolve) => setTimeout(resolve, 2000 * Math.pow(2, attempt - 1)));
+        } else {
+          throw error;
+        }
       }
     }
   } catch (error) {
     const errMsg = error instanceof Error ? error.message : String(error);
-    log("Auto-capture execution error", { error: errMsg });
+    log(`Auto-capture final error after ${attempt} attempts`, { error: errMsg });
     if (CONFIG.showErrorToasts) {
       const shortReason = errMsg.length > 100 ? errMsg.substring(0, 100) + "..." : errMsg;
       await ctx.client?.tui
@@ -156,13 +153,7 @@ export async function performAutoCapture(
         })
         .catch(() => {});
     }
-    throw error;
   } finally {
-    // Release any in-progress claim that did not reach a terminal state.
-    // This covers both early returns (no AI response yet, missing client,
-    // empty content) and exceptions (LLM failure, network error). Without
-    // releasing here, the prompt would remain locked at captured=2 with no
-    // automatic recovery path until the next plugin restart.
     if (claimedPromptId !== null) {
       try {
         userPromptManager.releaseClaim(claimedPromptId);

--- a/src/services/auto-capture.ts
+++ b/src/services/auto-capture.ts
@@ -11,6 +11,7 @@ interface ToolCallInfo {
 }
 
 const MAX_TOOL_INPUT_LENGTH = 100;
+const RETRY_BASE_DELAY_MS = 2000;
 
 let isCaptureRunning = false;
 
@@ -131,7 +132,9 @@ export async function performAutoCapture(
 
         if (attempt < maxRetries) {
           log(`Auto-capture warning (attempt ${attempt}/${maxRetries})`, { error: errMsg });
-          await new Promise((resolve) => setTimeout(resolve, 2000 * Math.pow(2, attempt - 1)));
+          await new Promise((resolve) =>
+            setTimeout(resolve, RETRY_BASE_DELAY_MS * Math.pow(2, attempt - 1))
+          );
         } else {
           throw error;
         }

--- a/src/services/auto-capture.ts
+++ b/src/services/auto-capture.ts
@@ -125,7 +125,36 @@ export async function performAutoCapture(
           })
           .catch(() => {});
       }
+    } else {
+      if (CONFIG.showErrorToasts) {
+        await ctx.client?.tui
+          .showToast({
+            body: {
+              title: "Auto Capture Failed",
+              message: "Memory save failed: " + (result.error || "Unknown error"),
+              variant: "error",
+              duration: 5000,
+            },
+          })
+          .catch(() => {});
+      }
     }
+  } catch (error) {
+    if (CONFIG.showErrorToasts) {
+      const errMsg = error instanceof Error ? error.message : String(error);
+      const shortReason = errMsg.length > 100 ? errMsg.substring(0, 100) + "..." : errMsg;
+      await ctx.client?.tui
+        .showToast({
+          body: {
+            title: "Auto Capture Failed",
+            message: shortReason,
+            variant: "error",
+            duration: 5000,
+          },
+        })
+        .catch(() => {});
+    }
+    throw error;
   } finally {
     // Release any in-progress claim that did not reach a terminal state.
     // This covers both early returns (no AI response yet, missing client,

--- a/src/services/auto-capture.ts
+++ b/src/services/auto-capture.ts
@@ -130,6 +130,8 @@ export async function performAutoCapture(
       } catch (error) {
         const errMsg = error instanceof Error ? error.message : String(error);
 
+        userPromptManager.recordFailedAttempt(prompt.id);
+
         if (attempt < maxRetries) {
           log(`Auto-capture warning (attempt ${attempt}/${maxRetries})`, { error: errMsg });
           await new Promise((resolve) =>

--- a/src/services/user-prompt/user-prompt-manager.ts
+++ b/src/services/user-prompt/user-prompt-manager.ts
@@ -18,6 +18,7 @@ export interface UserPrompt {
   captured: boolean;
   userLearningCaptured: boolean;
   linkedMemoryId: string | null;
+  capture_attempts: number;
 }
 
 export class UserPromptManager {
@@ -89,7 +90,7 @@ export class UserPromptManager {
     const maxRetries = CONFIG.autoCaptureMaxRetries ?? 3;
     const stmt = this.db.prepare(`
       SELECT * FROM user_prompts 
-      WHERE session_id = ? AND captured = 0 AND capture_attempts <= ?
+      WHERE session_id = ? AND captured = 0 AND capture_attempts < ?
       ORDER BY created_at DESC 
       LIMIT 1
     `);
@@ -145,7 +146,7 @@ export class UserPromptManager {
   countUncapturedPrompts(): number {
     const maxRetries = CONFIG.autoCaptureMaxRetries ?? 3;
     const stmt = this.db.prepare(
-      `SELECT COUNT(*) as count FROM user_prompts WHERE captured = 0 AND capture_attempts <= ?`
+      `SELECT COUNT(*) as count FROM user_prompts WHERE captured = 0 AND capture_attempts < ?`
     );
     const row = stmt.get(maxRetries) as any;
     return row?.count || 0;
@@ -155,7 +156,7 @@ export class UserPromptManager {
     const maxRetries = CONFIG.autoCaptureMaxRetries ?? 3;
     const stmt = this.db.prepare(`
       SELECT * FROM user_prompts 
-      WHERE captured = 0 AND capture_attempts <= ?
+      WHERE captured = 0 AND capture_attempts < ?
       ORDER BY capture_attempts ASC, created_at ASC 
       LIMIT ?
     `);
@@ -290,6 +291,7 @@ export class UserPromptManager {
       captured: row.captured === 1,
       userLearningCaptured: row.user_learning_captured === 1,
       linkedMemoryId: row.linked_memory_id,
+      capture_attempts: row.capture_attempts || 0,
     };
   }
 }

--- a/src/services/user-prompt/user-prompt-manager.ts
+++ b/src/services/user-prompt/user-prompt-manager.ts
@@ -86,14 +86,15 @@ export class UserPromptManager {
   }
 
   getLastUncapturedPrompt(sessionId: string): UserPrompt | null {
+    const maxRetries = CONFIG.autoCaptureMaxRetries ?? 3;
     const stmt = this.db.prepare(`
       SELECT * FROM user_prompts 
-      WHERE session_id = ? AND captured = 0 AND capture_attempts < 5
+      WHERE session_id = ? AND captured = 0 AND capture_attempts <= ?
       ORDER BY created_at DESC 
       LIMIT 1
     `);
 
-    const row = stmt.get(sessionId) as any;
+    const row = stmt.get(sessionId, maxRetries) as any;
     if (!row) return null;
 
     return this.rowToPrompt(row);
@@ -135,22 +136,24 @@ export class UserPromptManager {
   }
 
   countUncapturedPrompts(): number {
+    const maxRetries = CONFIG.autoCaptureMaxRetries ?? 3;
     const stmt = this.db.prepare(
-      `SELECT COUNT(*) as count FROM user_prompts WHERE captured = 0 AND capture_attempts < 5`
+      `SELECT COUNT(*) as count FROM user_prompts WHERE captured = 0 AND capture_attempts <= ?`
     );
-    const row = stmt.get() as any;
+    const row = stmt.get(maxRetries) as any;
     return row?.count || 0;
   }
 
   getUncapturedPrompts(limit: number): UserPrompt[] {
+    const maxRetries = CONFIG.autoCaptureMaxRetries ?? 3;
     const stmt = this.db.prepare(`
       SELECT * FROM user_prompts 
-      WHERE captured = 0 AND capture_attempts < 5
+      WHERE captured = 0 AND capture_attempts <= ?
       ORDER BY capture_attempts ASC, created_at ASC 
       LIMIT ?
     `);
 
-    const rows = stmt.all(limit) as any[];
+    const rows = stmt.all(maxRetries, limit) as any[];
     return rows.map((row) => this.rowToPrompt(row));
   }
 

--- a/src/services/user-prompt/user-prompt-manager.ts
+++ b/src/services/user-prompt/user-prompt-manager.ts
@@ -39,11 +39,20 @@ export class UserPromptManager {
         project_path TEXT,
         content TEXT NOT NULL,
         created_at INTEGER NOT NULL,
-        captured BOOLEAN DEFAULT 0,
+        captured INTEGER DEFAULT 0,
         user_learning_captured BOOLEAN DEFAULT 0,
-        linked_memory_id TEXT
+        linked_memory_id TEXT,
+        capture_attempts INTEGER DEFAULT 0
       )
     `);
+
+    try {
+      this.db.run("ALTER TABLE user_prompts ADD COLUMN capture_attempts INTEGER DEFAULT 0");
+    } catch (error: any) {
+      if (!error.message.includes("duplicate column name")) {
+        console.warn("Failed to add capture_attempts column:", error.message);
+      }
+    }
 
     this.db.run("UPDATE user_prompts SET captured = 0 WHERE captured = 2");
 
@@ -79,7 +88,7 @@ export class UserPromptManager {
   getLastUncapturedPrompt(sessionId: string): UserPrompt | null {
     const stmt = this.db.prepare(`
       SELECT * FROM user_prompts 
-      WHERE session_id = ? AND captured = 0
+      WHERE session_id = ? AND captured = 0 AND capture_attempts < 5
       ORDER BY created_at DESC 
       LIMIT 1
     `);
@@ -102,7 +111,7 @@ export class UserPromptManager {
 
   claimPrompt(promptId: string): boolean {
     const stmt = this.db.prepare(
-      `UPDATE user_prompts SET captured = 2 WHERE id = ? AND captured = 0`
+      `UPDATE user_prompts SET captured = 2, capture_attempts = capture_attempts + 1 WHERE id = ? AND captured = 0`
     );
     const result = stmt.run(promptId);
     return result.changes > 0;
@@ -126,7 +135,9 @@ export class UserPromptManager {
   }
 
   countUncapturedPrompts(): number {
-    const stmt = this.db.prepare(`SELECT COUNT(*) as count FROM user_prompts WHERE captured = 0`);
+    const stmt = this.db.prepare(
+      `SELECT COUNT(*) as count FROM user_prompts WHERE captured = 0 AND capture_attempts < 5`
+    );
     const row = stmt.get() as any;
     return row?.count || 0;
   }
@@ -134,8 +145,8 @@ export class UserPromptManager {
   getUncapturedPrompts(limit: number): UserPrompt[] {
     const stmt = this.db.prepare(`
       SELECT * FROM user_prompts 
-      WHERE captured = 0 
-      ORDER BY created_at ASC 
+      WHERE captured = 0 AND capture_attempts < 5
+      ORDER BY capture_attempts ASC, created_at ASC 
       LIMIT ?
     `);
 

--- a/src/services/user-prompt/user-prompt-manager.ts
+++ b/src/services/user-prompt/user-prompt-manager.ts
@@ -112,10 +112,17 @@ export class UserPromptManager {
 
   claimPrompt(promptId: string): boolean {
     const stmt = this.db.prepare(
-      `UPDATE user_prompts SET captured = 2, capture_attempts = capture_attempts + 1 WHERE id = ? AND captured = 0`
+      `UPDATE user_prompts SET captured = 2 WHERE id = ? AND captured = 0`
     );
     const result = stmt.run(promptId);
     return result.changes > 0;
+  }
+
+  recordFailedAttempt(promptId: string): void {
+    const stmt = this.db.prepare(
+      `UPDATE user_prompts SET capture_attempts = capture_attempts + 1 WHERE id = ?`
+    );
+    stmt.run(promptId);
   }
 
   /**

--- a/tests/user-prompt-manager-claim.test.ts
+++ b/tests/user-prompt-manager-claim.test.ts
@@ -114,4 +114,16 @@ describe("UserPromptManager.claimPrompt / releaseClaim", () => {
     expect(mgr.claimPrompt(id)).toBe(true);
     expect(getRawCaptured(id)).toBe(2);
   });
+
+  it("ignores prompts that have exceeded max retries", () => {
+    const id = mgr.savePrompt("session-retries", "msg-1", "/path", "hello retry");
+
+    for (let i = 0; i < 4; i++) {
+      mgr.claimPrompt(id);
+      mgr.releaseClaim(id);
+    }
+
+    const prompt = mgr.getLastUncapturedPrompt("session-retries");
+    expect(prompt).toBeNull();
+  });
 });

--- a/tests/user-prompt-manager-claim.test.ts
+++ b/tests/user-prompt-manager-claim.test.ts
@@ -119,8 +119,7 @@ describe("UserPromptManager.claimPrompt / releaseClaim", () => {
     const id = mgr.savePrompt("session-retries", "msg-1", "/path", "hello retry");
 
     for (let i = 0; i < 4; i++) {
-      mgr.claimPrompt(id);
-      mgr.releaseClaim(id);
+      mgr.recordFailedAttempt(id);
     }
 
     const prompt = mgr.getLastUncapturedPrompt("session-retries");


### PR DESCRIPTION
Fixes #134 

### Problem
Previously, when Auto Capture encountered a genuine error (such as LLM generation timeouts, unavailable clients, or database persistence failures), it failed completely silently. Users had no idea their memories weren't being saved. 

Furthermore, any transient error would leave the prompt stuck, causing the `session.idle` event to silently try to capture the exact same broken prompt infinitely in the background.

### Solution
This PR overhauls the error handling and retry mechanics of the auto-capture system:

1. **Surfaced Error Toasts:** True failures now display a red UI Error Toast to the user, truncating long API error messages for readability. Intentional skips (e.g., non-technical chats, or "not ready yet" empty responses) correctly bypass the toast and remain entirely silent.
2. **Explicit Logging:** Added precise `log()` statements for execution failures and retries, ensuring developers can debug capture issues even if a user has UI toasts disabled.
3. **Internal Retry Loop with Exponential Backoff:** Re-architected `performAutoCapture` to handle retries *internally* within a single background process, using exponential backoff (`2s`, `4s`, `8s`). This avoids relying on the user to repeatedly trigger `session.idle` events to drain the queue.
4. **Persistent Retry Budget:** 
   - Introduced `CONFIG.autoCaptureMaxRetries` (defaults to 3).
   - Added a `capture_attempts` column to the `user_prompts` SQLite table to track failures across application restarts.
   - The retry counter is **only** incremented on true persistence or LLM failures (via the new `recordFailedAttempt` method). Intentional skips and "not ready yet" scenarios no longer consume the retry budget.
   - Fixed an amplification bug by ensuring the internal loop counter strictly syncs with the database state, preventing a prompt from being tried more than exactly `maxRetries` times globally.

### Testing
- ✅ Added `test(auto-capture): add test case for max retries` to `tests/user-prompt-manager-claim.test.ts`.
- ✅ Verified locally: Dummy API keys correctly trigger a silent, internal exponential backoff loop before displaying a single Error Toast, while empty responses skip cleanly without incrementing the failure counter.