### PR TITLE
fix: request assistant reply for structured output

### DIFF
--- a/src/services/ai/opencode-provider.ts
+++ b/src/services/ai/opencode-provider.ts
@@ -91,7 +91,9 @@ export async function generateStructuredOutput<T>(opts: StructuredOutputOptions<
         schema: jsonSchema as Record<string, unknown>,
         ...(retryCount !== undefined ? { retryCount } : {}),
       },
-      noReply: true,
+      // Structured output is produced by opencode's assistant loop; noReply is
+      // context-only and returns before `info.structured` can be populated.
+      noReply: false,
     });
 
     const data = (

--- a/tests/opencode-provider.test.ts
+++ b/tests/opencode-provider.test.ts
@@ -146,7 +146,7 @@ describe("generateStructuredOutput", () => {
       modelID: "gpt-4o-mini",
     });
     expect(promptBody.system).toBe("system");
-    expect(promptBody.noReply).toBe(true);
+    expect(promptBody.noReply).toBe(false);
     const format = promptBody.format as Record<string, unknown>;
     expect(format.type).toBe("json_schema");
     expect(format.schema).toBeDefined();


### PR DESCRIPTION
## Summary

- What changed: Use `noReply: false` for transient OpenCode structured-output prompts and update the opencode-provider regression test.
- Why: OpenCode treats `noReply: true` as context-only, returning before the assistant loop that populates `info.structured`.
- Current phase: Ready for review.

## Scope

- In scope: `generateStructuredOutput()` calls through OpenCode v2 `session.prompt`; related unit test expectation.
- Out of scope: External provider implementations, auto-capture retry behavior, embedding/search behavior.
- Risk level: Low; the structured request already uses a transient session that is deleted afterward.

## Deployment Targets

- Impacted services: OpenCode plugin runtime only.
- Restart/deploy needed: Users need to restart OpenCode after updating the plugin.
- Target environment: Any environment using `opencodeProvider` + `opencodeModel` for auto-capture/profile structured output.
- Rollback note: Revert this commit to restore the previous `noReply: true` request behavior.

## Acceptance Plan

- Acceptance criteria: Structured-output prompts enter the assistant loop and return `info.structured`; transient sessions are still deleted.
- Evidence to collect: Unit and full test suite results.
- Required checks: Repository CI, if configured.
- Manual verification needed: Optional, against a live OpenCode server/provider.

## Validation

- Commands run:
  - `bun test tests/opencode-provider.test.ts`
  - `bun run typecheck`
  - `bun run format:check`
  - `bun run build && bun test`
- Result: Passed.
- Evidence links/log snippets: Final full test run: `156 pass, 0 fail`.
