### PR TITLE
fix(auto-capture): reuse injected opencode client

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -45,11 +45,13 @@ export const OpenCodeMemPlugin: Plugin = async (ctx: PluginInput) => {
 
   (async () => {
     try {
-      const { setConnectedProviders, setV2Client, createV2Client } =
+      const { createStructuredOutputClient, setConnectedProviders, setV2Client } =
         await import("./services/ai/opencode-provider.js");
-      setV2Client(createV2Client(ctx.serverUrl));
+      setConnectedProviders([]);
+      setV2Client(undefined);
       const providerResult = await ctx.client.provider.list();
       if (providerResult.data?.connected) {
+        setV2Client(createStructuredOutputClient(ctx.client));
         setConnectedProviders(providerResult.data.connected);
       }
     } catch (error) {

--- a/src/services/ai/opencode-provider.ts
+++ b/src/services/ai/opencode-provider.ts
@@ -11,10 +11,42 @@
  */
 
 import type { z } from "zod";
-import { createOpencodeClient, type OpencodeClient } from "@opencode-ai/sdk/v2/client";
+import { createOpencodeClient } from "@opencode-ai/sdk/v2/client";
+
+type SessionCreateResult = {
+  data?: { id?: string };
+  id?: string;
+  error?: { message?: string; data?: { message?: string } };
+  response?: { status?: number; statusText?: string };
+};
+
+type SessionPromptResult = {
+  data?: {
+    info?: {
+      structured?: unknown;
+      error?: { name: string; data?: { message?: string } };
+    };
+  };
+};
+
+export interface StructuredOutputClient {
+  session: {
+    create(input: Record<string, unknown>): Promise<SessionCreateResult>;
+    prompt(input: Record<string, unknown>): Promise<SessionPromptResult>;
+    delete(input: Record<string, unknown>): Promise<unknown>;
+  };
+}
+
+type InjectedOpencodeClient = {
+  session: {
+    create(options: unknown): Promise<unknown>;
+    prompt(options: unknown): Promise<unknown>;
+    delete(options: unknown): Promise<unknown>;
+  };
+};
 
 let _connectedProviders: Set<string> = new Set();
-let _v2Client: OpencodeClient | undefined;
+let _v2Client: StructuredOutputClient | undefined;
 
 export function setConnectedProviders(providers: string[]): void {
   _connectedProviders = new Set(providers);
@@ -24,21 +56,78 @@ export function isProviderConnected(providerName: string): boolean {
   return _connectedProviders.has(providerName);
 }
 
-export function setV2Client(client: OpencodeClient): void {
+export function setV2Client(client: StructuredOutputClient | undefined): void {
   _v2Client = client;
 }
 
-export function getV2Client(): OpencodeClient | undefined {
+export function getV2Client(): StructuredOutputClient | undefined {
   return _v2Client;
 }
 
-export function createV2Client(serverUrl: URL | string): OpencodeClient {
+export function createV2Client(serverUrl: URL | string): StructuredOutputClient {
   const baseUrl = typeof serverUrl === "string" ? serverUrl : serverUrl.toString();
-  return createOpencodeClient({ baseUrl });
+  return createOpencodeClient({ baseUrl }) as unknown as StructuredOutputClient;
+}
+
+function compactObject(value: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(value).filter(([, v]) => v !== undefined));
+}
+
+export function createStructuredOutputClient(
+  client: InjectedOpencodeClient
+): StructuredOutputClient {
+  return {
+    session: {
+      create: (input) =>
+        client.session.create({
+          query: compactObject({ directory: input.directory, workspace: input.workspace }),
+          body: compactObject({
+            parentID: input.parentID,
+            title: input.title,
+            agent: input.agent,
+            model: input.model,
+            metadata: input.metadata,
+            permission: input.permission,
+            workspaceID: input.workspaceID,
+          }),
+        }) as Promise<SessionCreateResult>,
+      prompt: (input) =>
+        client.session.prompt({
+          path: { id: input.sessionID },
+          query: compactObject({ directory: input.directory, workspace: input.workspace }),
+          body: compactObject({
+            messageID: input.messageID,
+            model: input.model,
+            agent: input.agent,
+            noReply: input.noReply,
+            tools: input.tools,
+            format: input.format,
+            system: input.system,
+            variant: input.variant,
+            parts: input.parts,
+          }),
+        }) as Promise<SessionPromptResult>,
+      delete: (input) =>
+        client.session.delete({
+          path: { id: input.sessionID },
+          query: compactObject({ directory: input.directory, workspace: input.workspace }),
+        }),
+    },
+  };
+}
+
+function summarizeCreateFailure(created: SessionCreateResult): string {
+  const status = created?.response?.status;
+  const statusText = created?.response?.statusText;
+  const message = created?.error?.message ?? created?.error?.data?.message;
+  const details = [status ? `status=${status}` : undefined, statusText, message]
+    .filter(Boolean)
+    .join(" ");
+  return details ? ` (${details})` : "";
 }
 
 export interface StructuredOutputOptions<T> {
-  client: OpencodeClient;
+  client: StructuredOutputClient;
   providerID: string;
   modelID: string;
   systemPrompt: string;
@@ -72,10 +161,12 @@ export async function generateStructuredOutput<T>(opts: StructuredOutputOptions<
     title: "opencode-mem capture",
     ...(directory ? { directory } : {}),
   });
-  const sessionID = (created as { data?: { id?: string } })?.data?.id;
+  const sessionID = created.data?.id ?? created.id;
   if (!sessionID) {
     throw new Error(
-      "opencode-mem: session.create returned no session id; cannot generate structured output"
+      `opencode-mem: session.create returned no session id${summarizeCreateFailure(
+        created
+      )}; cannot generate structured output`
     );
   }
 
@@ -94,16 +185,7 @@ export async function generateStructuredOutput<T>(opts: StructuredOutputOptions<
       noReply: true,
     });
 
-    const data = (
-      promptResult as {
-        data?: {
-          info?: {
-            structured?: unknown;
-            error?: { name: string; data?: { message?: string } };
-          };
-        };
-      }
-    ).data;
+    const data = promptResult.data;
 
     const info = data?.info;
     if (!info) {

--- a/tests/opencode-provider.test.ts
+++ b/tests/opencode-provider.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { z } from "zod";
 import {
+  createStructuredOutputClient,
   createV2Client,
   generateStructuredOutput,
   getV2Client,
@@ -93,6 +94,65 @@ describe("v2 client cache", () => {
     expect(typeof client.session.create).toBe("function");
     expect(typeof client.session.prompt).toBe("function");
     expect(typeof client.session.delete).toBe("function");
+  });
+});
+
+describe("structured output client adapter", () => {
+  it("uses the injected opencode client instead of opening a new serverUrl client", async () => {
+    const calls: Array<{ method: string; options: unknown }> = [];
+    const injectedClient = {
+      session: {
+        create: async (options: unknown) => {
+          calls.push({ method: "create", options });
+          return { data: { id: "ses_injected" } };
+        },
+        prompt: async (options: unknown) => {
+          calls.push({ method: "prompt", options });
+          return {
+            data: {
+              info: { structured: { topic: "ctx-client", count: 1 } },
+              parts: [],
+            },
+          };
+        },
+        delete: async (options: unknown) => {
+          calls.push({ method: "delete", options });
+          return { data: true };
+        },
+      },
+    };
+
+    const result = await generateStructuredOutput({
+      client: createStructuredOutputClient(injectedClient),
+      providerID: "openai",
+      modelID: "gpt-5.4-mini",
+      systemPrompt: "system",
+      userPrompt: "user",
+      schema,
+      directory: "/repo",
+      retryCount: 2,
+    });
+
+    expect(result).toEqual({ topic: "ctx-client", count: 1 });
+    expect(calls.map((c) => c.method)).toEqual(["create", "prompt", "delete"]);
+    expect(calls[0]?.options).toEqual({
+      query: { directory: "/repo" },
+      body: { title: "opencode-mem capture" },
+    });
+    expect(calls[1]?.options).toMatchObject({
+      path: { id: "ses_injected" },
+      query: { directory: "/repo" },
+      body: {
+        model: { providerID: "openai", modelID: "gpt-5.4-mini" },
+        system: "system",
+        noReply: true,
+        format: { type: "json_schema", retryCount: 2 },
+      },
+    });
+    expect(calls[2]?.options).toEqual({
+      path: { id: "ses_injected" },
+      query: { directory: "/repo" },
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

- What changed: Auto-capture now builds its structured-output session client from the injected OpenCode `ctx.client` instead of creating a second client from `ctx.serverUrl`. `session.create` failures now include underlying status/error details when available.
- Why: In no-port OpenCode sessions, `ctx.serverUrl` can be `http://localhost:4096/` even when no REST API is listening there, causing `session.create returned no session id` during auto-capture.
- Current phase: Ready for review. Closes #145.

## Scope

- In scope: Structured-output auto-capture client initialization and regression coverage for the injected-client adapter.
- Out of scope: Provider/model timeout tuning, storage/indexing behavior, web UI behavior.
- Risk level: Low/medium; changes the internal client used for auto-capture session create/prompt/delete while preserving the existing request shapes.

## Deployment Targets

- Impacted services: `opencode-mem` plugin auto-capture and user-profile structured-output paths that use the shared opencode provider client.
- Restart/deploy needed: Users need to restart OpenCode after upgrading the plugin.
- Target environment: OpenCode plugin runtime.
- Rollback note: Revert this commit to restore the previous `ctx.serverUrl` client path.

## Acceptance Plan

- Acceptance criteria: Auto-capture should not fail with no session id solely because `ctx.serverUrl` points to an unreachable default port; structured-output calls should use the injected client and still pass `format`, `system`, `model`, and `parts` correctly.
- Evidence to collect: Regression test verifies `createStructuredOutputClient()` maps v2-style calls onto the injected client without opening a new serverUrl client.
- Required checks: Typecheck, build, formatter check, targeted provider tests, full test suite.
- Manual verification needed: Optional validation in a no-port OpenCode runtime after publishing.

## Validation

- Commands run:
  - `bun test tests/opencode-provider.test.ts`
  - `bun run format:check`
  - `bun run typecheck`
  - `bun run build`
  - `bun test`
- Result: All passed after formatting.
- Evidence links/log snippets:
  - Targeted test: 12 pass, 0 fail
  - Full test suite: 157 pass, 0 fail
