### PR TITLE
Avoid forced process exit on shutdown

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -129,6 +129,10 @@ export const OpenCodeMemPlugin: Plugin = async (ctx: PluginInput) => {
   }
 
   const cleanupPlugin = async () => {
+    if (idleTimeout) {
+      clearTimeout(idleTimeout);
+      idleTimeout = null;
+    }
     if (webServer) await webServer.stop();
     if (memoryClient) memoryClient.close();
   };
@@ -136,10 +140,9 @@ export const OpenCodeMemPlugin: Plugin = async (ctx: PluginInput) => {
   const shutdownHandler = async () => {
     try {
       await cleanupPlugin();
-      process.exit(0);
     } catch (error) {
       log("Shutdown error", { error: String(error) });
-      process.exit(1);
+      process.exitCode = 1;
     }
   };
 

--- a/tests/plugin-shutdown.test.ts
+++ b/tests/plugin-shutdown.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+
+describe("plugin shutdown", () => {
+  it("does not force host process exit from signal handlers", () => {
+    const source = readFileSync(new URL("../src/index.ts", import.meta.url), "utf-8");
+
+    expect(source).not.toContain("process.exit(");
+  });
+
+  it("clears pending idle auto-capture work during cleanup", () => {
+    const source = readFileSync(new URL("../src/index.ts", import.meta.url), "utf-8");
+
+    expect(source).toContain("clearTimeout(idleTimeout)");
+    expect(source).toContain("idleTimeout = null");
+  });
+});


### PR DESCRIPTION
Closes #114

- Remove `process.exit()` calls from the SIGINT/SIGTERM shutdown handler
- Preserve cleanup and error logging
- Clear pending idle auto-capture timeout during cleanup
- Set `process.exitCode = 1` on cleanup failure without forcing host process teardown
- Add regression coverage so `process.exit()` is not reintroduced

Tested:
- npx bun test tests/plugin-shutdown.test.ts tests/plugin-loader-contract.test.ts
- npx bun run typecheck
- npx bun run build
- npx bun test