### PR TITLE
feat: `opencodeModel: "inherit"` — capture with the session's own model

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ Supported providers: any provider listed by `opencode providers list` (e.g. `ant
 
 If `opencodeProvider` and `opencodeModel` are set, they take precedence over the manual `memoryProvider` settings below.
 
+**Follow the session model:** set `"opencodeModel": "inherit"` to capture each prompt with the exact provider/model opencode used to answer it (recorded per message via the `chat.params` hook). This is useful if you switch models often or use several local backends; captures then always use the model that produced the conversation, and pinned ids can’t become stale. `opencodeProvider` is still required as the normal config gate, and is used if a prompt has no recorded model.
+
 **Fallback:** Manual API configuration (if not using opencodeProvider):
 
 ```jsonc

--- a/src/index.ts
+++ b/src/index.ts
@@ -309,6 +309,16 @@ export const OpenCodeMemPlugin: Plugin = async (ctx: PluginInput) => {
       }
     },
 
+    "chat.params": async (input) => {
+      if (!isConfigured() || CONFIG.opencodeModel !== "inherit") return;
+
+      try {
+        userPromptManager.setPromptModel(input.message.id, input.model.providerID, input.model.id);
+      } catch (error) {
+        log("chat.params: ERROR", { error: String(error) });
+      }
+    },
+
     tool: {
       memory: tool({
         description: `Manage and query project memory (MATCH USER LANGUAGE: ${getLanguageName(CONFIG.autoCaptureLanguage || "en")}). Use 'search' with technical keywords/tags, 'add' to store knowledge, 'profile' for preferences. Search/list scope: project or all-projects.`,

--- a/src/services/auto-capture.ts
+++ b/src/services/auto-capture.ts
@@ -98,7 +98,7 @@ async function capturePrompt(
 
         let summaryResult: { summary: string; type: string; tags: string[] } | null;
         try {
-          summaryResult = await generateSummary(context, sessionID, prompt.content);
+          summaryResult = await generateSummary(context, sessionID, prompt.content, prompt);
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);
           throw new Error(`Summary generation failed: ${message}`);
@@ -338,7 +338,8 @@ function buildMarkdownContext(
 async function generateSummary(
   context: string,
   sessionID: string,
-  userPrompt: string
+  userPrompt: string,
+  prompt?: { providerId: string | null; modelId: string | null }
 ): Promise<{ summary: string; type: string; tags: string[] } | null> {
   // Opencode provider path (when opencodeProvider + opencodeModel configured)
   if (CONFIG.opencodeProvider && CONFIG.opencodeModel) {
@@ -350,9 +351,24 @@ async function generateSummary(
       const { isProviderConnected, getV2Client, generateStructuredOutput } =
         await import("./ai/opencode-provider.js");
 
-      if (!isProviderConnected(CONFIG.opencodeProvider)) {
+      // "inherit" resolves to the model opencode used for the captured prompt
+      // (recorded by the chat.params hook). Without a concrete model id, the
+      // provider path cannot issue a structured-output request.
+      let providerID = CONFIG.opencodeProvider;
+      let modelID = CONFIG.opencodeModel;
+      if (modelID === "inherit") {
+        if (!prompt?.providerId || !prompt?.modelId) {
+          throw new Error(
+            "opencode-mem: opencodeModel is 'inherit' but no session model was recorded for this prompt"
+          );
+        }
+        providerID = prompt.providerId;
+        modelID = prompt.modelId;
+      }
+
+      if (!isProviderConnected(providerID)) {
         throw new Error(
-          `opencode provider '${CONFIG.opencodeProvider}' is not connected. Check your opencode provider configuration.`
+          `opencode provider '${providerID}' is not connected. Check your opencode provider configuration.`
         );
       }
 
@@ -403,8 +419,8 @@ Analyze this conversation. If it contains technical work (code, bugs, features, 
 
       const result = await generateStructuredOutput({
         client: v2Client,
-        providerID: CONFIG.opencodeProvider,
-        modelID: CONFIG.opencodeModel,
+        providerID,
+        modelID,
         systemPrompt,
         userPrompt: aiPrompt,
         schema,

--- a/src/services/user-prompt/user-prompt-manager.ts
+++ b/src/services/user-prompt/user-prompt-manager.ts
@@ -19,6 +19,8 @@ export interface UserPrompt {
   userLearningCaptured: boolean;
   linkedMemoryId: string | null;
   capture_attempts: number;
+  providerId: string | null;
+  modelId: string | null;
 }
 
 export class UserPromptManager {
@@ -43,7 +45,9 @@ export class UserPromptManager {
         captured INTEGER DEFAULT 0,
         user_learning_captured BOOLEAN DEFAULT 0,
         linked_memory_id TEXT,
-        capture_attempts INTEGER DEFAULT 0
+        capture_attempts INTEGER DEFAULT 0,
+        provider_id TEXT,
+        model_id TEXT
       )
     `);
 
@@ -52,6 +56,16 @@ export class UserPromptManager {
     } catch (error: any) {
       if (!error.message.includes("duplicate column name")) {
         console.warn("Failed to add capture_attempts column:", error.message);
+      }
+    }
+
+    for (const column of ["provider_id TEXT", "model_id TEXT"]) {
+      try {
+        this.db.run(`ALTER TABLE user_prompts ADD COLUMN ${column}`);
+      } catch (error: any) {
+        if (!error.message.includes("duplicate column name")) {
+          console.warn(`Failed to add ${column.split(" ")[0]} column:`, error.message);
+        }
       }
     }
 
@@ -84,6 +98,13 @@ export class UserPromptManager {
 
     stmt.run(id, sessionId, messageId, projectPath, content, now);
     return id;
+  }
+
+  setPromptModel(messageId: string, providerId: string, modelId: string): void {
+    const stmt = this.db.prepare(
+      `UPDATE user_prompts SET provider_id = ?, model_id = ? WHERE message_id = ?`
+    );
+    stmt.run(providerId, modelId, messageId);
   }
 
   getLastUncapturedPrompt(sessionId: string): UserPrompt | null {
@@ -304,6 +325,8 @@ export class UserPromptManager {
       userLearningCaptured: row.user_learning_captured === 1,
       linkedMemoryId: row.linked_memory_id,
       capture_attempts: row.capture_attempts || 0,
+      providerId: row.provider_id ?? null,
+      modelId: row.model_id ?? null,
     };
   }
 }


### PR DESCRIPTION
## Motivation

Pinned `opencodeModel` ids rot: when a provider renames a model (or a local endpoint changes its served model id), auto-capture silently fails at `session.create` on every prompt until someone notices the log spam. That is how I found this — capture had been broken for days on a stale local-model id. Separately, users who switch models during the day may prefer each conversation to be captured by the model that actually produced it.

## What this does

`"opencodeModel": "inherit"` makes auto-capture use the exact provider/model opencode resolved for the captured prompt:

- a `chat.params` hook records `input.model.providerID` / `input.model.id` onto the prompt's existing `user_prompts` row (two new nullable columns, added with the same duplicate-column-guarded `ALTER TABLE` pattern as `capture_attempts`), keyed by `message.id` — the same key capture already uses, so the mapping is exact rather than inferred from transcript position;
- at capture time, `"inherit"` resolves provider/model from the stored row; the existing `isProviderConnected` guard runs against the resolved provider;
- if a prompt has no recorded model (predates the upgrade, or the provider path didn't invoke `chat.params`), capture throws and the existing retry/cap machinery handles it — it never guesses.

Pinned configuration behaves exactly as before; the hook returns immediately unless `"inherit"` is configured.

## Notes for review

- `opencodeProvider` must still be set (the existing `opencodeProvider && opencodeModel` gate is untouched for diff minimality); with `"inherit"` its value is only used as a gate. Happy to change the gate if you prefer.
- On opencode v1.17.11 I observed `chat.params` firing reliably for models served through the standard providers, but not for every custom npm-provider path — the hard-error fallback covers those prompts. Worth knowing for docs/support.

## Testing

- `tsc --noEmit` and Prettier clean; migration verified against an existing populated `user-prompts.db` (old rows read back with `null` model fields).
- Live-tested against opencode v1.17.11: sessions on a local llama.cpp-served model recorded `provider_id`/`model_id` correctly on their prompt rows, and capture consumed the recorded model (verified via capture-session behavior/logs).
- Rows without recorded models fail capture with the new explicit error and are retried/capped by the existing machinery.
