### PR TITLE
Refactor/auto capture provider readiness

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import { homedir } from "node:os";
 import { stripJsoncComments } from "./services/jsonc.js";
 import { resolveSecretValue } from "./services/secret-resolver.js";
-import { allowsMissingApiKey, isPlaceholderApiKey } from "./services/ai/api-key-placeholder.js";
+import { isPlaceholderApiKey } from "./services/ai/api-key-placeholder.js";
 
 const CONFIG_DIR = join(homedir(), ".config", "opencode");
 const DATA_DIR = join(homedir(), ".opencode-mem");
@@ -606,7 +606,7 @@ function hasValue(value: string | undefined): boolean {
   return typeof value === "string" && value.trim().length > 0;
 }
 
-export { allowsMissingApiKey, isPlaceholderApiKey };
+export { isPlaceholderApiKey };
 
 export function getAutoCaptureProviderStatus(
   config: AutoCaptureProviderRuntimeConfig
@@ -625,21 +625,13 @@ export function getAutoCaptureProviderStatus(
   const hasMemoryApiUrl = hasValue(config.memoryApiUrl);
   const hasMemoryApiKey = hasValue(config.memoryApiKey);
   const hasPlaceholderMemoryApiKey = isPlaceholderApiKey(config.memoryApiKey);
-  const missingMemoryApiKeyAllowed = allowsMissingApiKey(config.memoryApiUrl);
 
   if (!hasMemoryModel) issues.push("memoryModel is not configured");
   if (!hasMemoryApiUrl) issues.push("memoryApiUrl is not configured");
-  if (hasMemoryApiUrl && !hasMemoryApiKey && !missingMemoryApiKeyAllowed) {
-    issues.push("memoryApiKey is not configured");
-  }
+  if (!hasMemoryApiKey) issues.push("memoryApiKey is not configured");
   if (hasPlaceholderMemoryApiKey) issues.push("memoryApiKey contains a placeholder value");
 
-  if (
-    hasMemoryModel &&
-    hasMemoryApiUrl &&
-    (hasMemoryApiKey || missingMemoryApiKeyAllowed) &&
-    !hasPlaceholderMemoryApiKey
-  ) {
+  if (hasMemoryModel && hasMemoryApiUrl && hasMemoryApiKey && !hasPlaceholderMemoryApiKey) {
     return { ready: true, mode: "manual", issues: [] };
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import { homedir } from "node:os";
 import { stripJsoncComments } from "./services/jsonc.js";
 import { resolveSecretValue } from "./services/secret-resolver.js";
-import { isPlaceholderApiKey } from "./services/ai/api-key-placeholder.js";
+import { allowsMissingApiKey, isPlaceholderApiKey } from "./services/ai/api-key-placeholder.js";
 
 const CONFIG_DIR = join(homedir(), ".config", "opencode");
 const DATA_DIR = join(homedir(), ".opencode-mem");
@@ -493,6 +493,8 @@ function getEmbeddingDimensions(model: string): number {
 }
 
 function buildConfig(fileConfig: OpenCodeMemConfig) {
+  const memoryApiKey = resolveSecretValue(fileConfig.memoryApiKey);
+
   return {
     storagePath: expandPath(fileConfig.storagePath ?? DEFAULTS.storagePath),
     userEmailOverride: fileConfig.userEmailOverride,
@@ -523,11 +525,18 @@ function buildConfig(fileConfig: OpenCodeMemConfig) {
       | "anthropic",
     memoryModel: fileConfig.memoryModel,
     memoryApiUrl: fileConfig.memoryApiUrl,
-    memoryApiKey: resolveSecretValue(fileConfig.memoryApiKey),
+    memoryApiKey,
     memoryTemperature: fileConfig.memoryTemperature,
     memoryExtraParams: fileConfig.memoryExtraParams,
     opencodeProvider: fileConfig.opencodeProvider,
     opencodeModel: fileConfig.opencodeModel,
+    autoCaptureProviderStatus: getAutoCaptureProviderStatus({
+      opencodeProvider: fileConfig.opencodeProvider,
+      opencodeModel: fileConfig.opencodeModel,
+      memoryModel: fileConfig.memoryModel,
+      memoryApiUrl: fileConfig.memoryApiUrl,
+      memoryApiKey,
+    }),
     vectorBackend: (fileConfig.vectorBackend ?? "usearch-first") as
       | "usearch-first"
       | "usearch"
@@ -581,20 +590,64 @@ export let CONFIG = buildConfig(_globalFileConfig);
 
 type RuntimeConfig = ReturnType<typeof buildConfig>;
 
+interface AutoCaptureProviderRuntimeConfig {
+  opencodeProvider?: string;
+  opencodeModel?: string;
+  memoryModel?: string;
+  memoryApiUrl?: string;
+  memoryApiKey?: string;
+}
+
+export type AutoCaptureProviderStatus =
+  | { ready: true; mode: "opencode" | "manual"; issues: [] }
+  | { ready: false; issues: string[] };
+
 function hasValue(value: string | undefined): boolean {
   return typeof value === "string" && value.trim().length > 0;
 }
 
-export { isPlaceholderApiKey };
+export { allowsMissingApiKey, isPlaceholderApiKey };
+
+export function getAutoCaptureProviderStatus(
+  config: AutoCaptureProviderRuntimeConfig
+): AutoCaptureProviderStatus {
+  const hasOpencodeProvider = hasValue(config.opencodeProvider);
+  const hasOpencodeModel = hasValue(config.opencodeModel);
+  if (hasOpencodeProvider && hasOpencodeModel) {
+    return { ready: true, mode: "opencode", issues: [] };
+  }
+
+  const issues: string[] = [];
+  if (!hasOpencodeProvider) issues.push("opencodeProvider is not configured");
+  if (!hasOpencodeModel) issues.push("opencodeModel is not configured");
+
+  const hasMemoryModel = hasValue(config.memoryModel);
+  const hasMemoryApiUrl = hasValue(config.memoryApiUrl);
+  const hasMemoryApiKey = hasValue(config.memoryApiKey);
+  const hasPlaceholderMemoryApiKey = isPlaceholderApiKey(config.memoryApiKey);
+  const missingMemoryApiKeyAllowed = allowsMissingApiKey(config.memoryApiUrl);
+
+  if (!hasMemoryModel) issues.push("memoryModel is not configured");
+  if (!hasMemoryApiUrl) issues.push("memoryApiUrl is not configured");
+  if (hasMemoryApiUrl && !hasMemoryApiKey && !missingMemoryApiKeyAllowed) {
+    issues.push("memoryApiKey is not configured");
+  }
+  if (hasPlaceholderMemoryApiKey) issues.push("memoryApiKey contains a placeholder value");
+
+  if (
+    hasMemoryModel &&
+    hasMemoryApiUrl &&
+    (hasMemoryApiKey || missingMemoryApiKeyAllowed) &&
+    !hasPlaceholderMemoryApiKey
+  ) {
+    return { ready: true, mode: "manual", issues: [] };
+  }
+
+  return { ready: false, issues };
+}
 
 export function hasAutoCaptureProviderConfig(config: RuntimeConfig = CONFIG): boolean {
-  const hasOpencodeProvider = hasValue(config.opencodeProvider) && hasValue(config.opencodeModel);
-  const hasManualProvider =
-    hasValue(config.memoryModel) &&
-    hasValue(config.memoryApiUrl) &&
-    !isPlaceholderApiKey(config.memoryApiKey);
-
-  return hasOpencodeProvider || hasManualProvider;
+  return getAutoCaptureProviderStatus(config).ready;
 }
 
 export function initConfig(directory: string): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,9 +17,18 @@ import type { MemoryType } from "./types/index.js";
 import { getLanguageName } from "./services/language-detector.js";
 import type { MemoryScope } from "./services/client.js";
 
+function logAutoCaptureProviderStatus(): void {
+  if (!CONFIG.autoCaptureEnabled || CONFIG.autoCaptureProviderStatus.ready) return;
+
+  log(
+    `Auto-capture disabled by configuration. Issues: ${CONFIG.autoCaptureProviderStatus.issues.join("; ")}.`
+  );
+}
+
 export const OpenCodeMemPlugin: Plugin = async (ctx: PluginInput) => {
   const { directory } = ctx;
   initConfig(directory);
+  logAutoCaptureProviderStatus();
   const tags = getTags(directory);
   let webServer: WebServer | null = null;
   let idleTimeout: Timer | null = null;

--- a/src/services/ai/api-key-placeholder.ts
+++ b/src/services/ai/api-key-placeholder.ts
@@ -14,16 +14,3 @@ export function isPlaceholderApiKey(value: string | undefined): boolean {
 
   return PLACEHOLDER_API_KEYS.has(value.trim().toLowerCase());
 }
-
-export function allowsMissingApiKey(apiUrl: string | undefined): boolean {
-  if (!apiUrl) {
-    return false;
-  }
-
-  try {
-    const url = new URL(apiUrl);
-    return ["localhost", "127.0.0.1", "::1", "0.0.0.0"].includes(url.hostname);
-  } catch {
-    return false;
-  }
-}

--- a/src/services/ai/api-key-placeholder.ts
+++ b/src/services/ai/api-key-placeholder.ts
@@ -14,3 +14,16 @@ export function isPlaceholderApiKey(value: string | undefined): boolean {
 
   return PLACEHOLDER_API_KEYS.has(value.trim().toLowerCase());
 }
+
+export function allowsMissingApiKey(apiUrl: string | undefined): boolean {
+  if (!apiUrl) {
+    return false;
+  }
+
+  try {
+    const url = new URL(apiUrl);
+    return ["localhost", "127.0.0.1", "::1", "0.0.0.0"].includes(url.hostname);
+  } catch {
+    return false;
+  }
+}

--- a/src/services/ai/provider-config.ts
+++ b/src/services/ai/provider-config.ts
@@ -16,6 +16,14 @@ interface ProviderConfigOverrides {
   iterationTimeout?: number;
 }
 
+function requireConfiguredField(value: string | undefined, fieldName: string): string {
+  if (!value) {
+    throw new Error(`Memory provider config invariant failed: ${fieldName} is not configured`);
+  }
+
+  return value;
+}
+
 export function buildMemoryProviderConfig(
   config: MemoryProviderRuntimeConfig,
   overrides: ProviderConfigOverrides = {}
@@ -30,14 +38,18 @@ export function buildMemoryProviderConfig(
   if (!memoryApiKey) issues.push("missing memoryApiKey");
   if (isPlaceholderApiKey(memoryApiKey)) issues.push("replace the placeholder memoryApiKey value");
 
-  if (issues.length > 0 || !memoryModel || !memoryApiUrl || !memoryApiKey) {
+  if (issues.length > 0) {
     throw new Error(`External API not configured for memory provider: ${issues.join("; ")}`);
   }
 
+  const configuredMemoryModel = requireConfiguredField(memoryModel, "memoryModel");
+  const configuredMemoryApiUrl = requireConfiguredField(memoryApiUrl, "memoryApiUrl");
+  const configuredMemoryApiKey = requireConfiguredField(memoryApiKey, "memoryApiKey");
+
   return {
-    model: memoryModel,
-    apiUrl: memoryApiUrl,
-    apiKey: memoryApiKey,
+    model: configuredMemoryModel,
+    apiUrl: configuredMemoryApiUrl,
+    apiKey: configuredMemoryApiKey,
     memoryTemperature: config.memoryTemperature,
     extraParams: config.memoryExtraParams,
     maxIterations: overrides.maxIterations ?? config.autoCaptureMaxIterations,

--- a/src/services/ai/provider-config.ts
+++ b/src/services/ai/provider-config.ts
@@ -1,5 +1,5 @@
 import type { ProviderConfig } from "./providers/base-provider.js";
-import { isPlaceholderApiKey } from "./api-key-placeholder.js";
+import { allowsMissingApiKey, isPlaceholderApiKey } from "./api-key-placeholder.js";
 
 interface MemoryProviderRuntimeConfig {
   memoryModel?: string;
@@ -20,8 +20,17 @@ export function buildMemoryProviderConfig(
   config: MemoryProviderRuntimeConfig,
   overrides: ProviderConfigOverrides = {}
 ): ProviderConfig {
-  if (!config.memoryModel || !config.memoryApiUrl) {
-    throw new Error("External API not configured for memory provider");
+  const memoryModel = config.memoryModel;
+  const memoryApiUrl = config.memoryApiUrl;
+
+  if (!memoryModel || !memoryApiUrl) {
+    const missingFields: string[] = [];
+    if (!memoryModel) missingFields.push("memoryModel");
+    if (!memoryApiUrl) missingFields.push("memoryApiUrl");
+
+    throw new Error(
+      `External API not configured for memory provider: missing ${missingFields.join(", ")}`
+    );
   }
 
   if (isPlaceholderApiKey(config.memoryApiKey)) {
@@ -30,9 +39,13 @@ export function buildMemoryProviderConfig(
     );
   }
 
+  if (!config.memoryApiKey && !allowsMissingApiKey(memoryApiUrl)) {
+    throw new Error("External API not configured for memory provider: missing memoryApiKey");
+  }
+
   return {
-    model: config.memoryModel,
-    apiUrl: config.memoryApiUrl,
+    model: memoryModel,
+    apiUrl: memoryApiUrl,
     apiKey: config.memoryApiKey,
     memoryTemperature: config.memoryTemperature,
     extraParams: config.memoryExtraParams,

--- a/src/services/ai/provider-config.ts
+++ b/src/services/ai/provider-config.ts
@@ -1,5 +1,5 @@
 import type { ProviderConfig } from "./providers/base-provider.js";
-import { allowsMissingApiKey, isPlaceholderApiKey } from "./api-key-placeholder.js";
+import { isPlaceholderApiKey } from "./api-key-placeholder.js";
 
 interface MemoryProviderRuntimeConfig {
   memoryModel?: string;
@@ -39,7 +39,7 @@ export function buildMemoryProviderConfig(
     );
   }
 
-  if (!config.memoryApiKey && !allowsMissingApiKey(memoryApiUrl)) {
+  if (!config.memoryApiKey) {
     throw new Error("External API not configured for memory provider: missing memoryApiKey");
   }
 

--- a/src/services/ai/provider-config.ts
+++ b/src/services/ai/provider-config.ts
@@ -22,31 +22,27 @@ export function buildMemoryProviderConfig(
 ): ProviderConfig {
   const memoryModel = config.memoryModel;
   const memoryApiUrl = config.memoryApiUrl;
+  const memoryApiKey = config.memoryApiKey;
+  const missingFields: string[] = [];
+  const issues: string[] = [];
 
-  if (!memoryModel || !memoryApiUrl) {
-    const missingFields: string[] = [];
-    if (!memoryModel) missingFields.push("memoryModel");
-    if (!memoryApiUrl) missingFields.push("memoryApiUrl");
+  if (!memoryModel) missingFields.push("memoryModel");
+  if (!memoryApiUrl) missingFields.push("memoryApiUrl");
+  if (!memoryApiKey) missingFields.push("memoryApiKey");
+  if (missingFields.length > 0) issues.push(`missing ${missingFields.join(", ")}`);
 
-    throw new Error(
-      `External API not configured for memory provider: missing ${missingFields.join(", ")}`
-    );
+  if (isPlaceholderApiKey(memoryApiKey)) {
+    issues.push("replace the placeholder memoryApiKey value");
   }
 
-  if (isPlaceholderApiKey(config.memoryApiKey)) {
-    throw new Error(
-      "External API not configured for memory provider: replace the placeholder memoryApiKey value"
-    );
-  }
-
-  if (!config.memoryApiKey) {
-    throw new Error("External API not configured for memory provider: missing memoryApiKey");
+  if (!memoryModel || !memoryApiUrl || !memoryApiKey || issues.length > 0) {
+    throw new Error(`External API not configured for memory provider: ${issues.join("; ")}`);
   }
 
   return {
     model: memoryModel,
     apiUrl: memoryApiUrl,
-    apiKey: config.memoryApiKey,
+    apiKey: memoryApiKey,
     memoryTemperature: config.memoryTemperature,
     extraParams: config.memoryExtraParams,
     maxIterations: overrides.maxIterations ?? config.autoCaptureMaxIterations,

--- a/src/services/ai/provider-config.ts
+++ b/src/services/ai/provider-config.ts
@@ -23,19 +23,14 @@ export function buildMemoryProviderConfig(
   const memoryModel = config.memoryModel;
   const memoryApiUrl = config.memoryApiUrl;
   const memoryApiKey = config.memoryApiKey;
-  const missingFields: string[] = [];
   const issues: string[] = [];
 
-  if (!memoryModel) missingFields.push("memoryModel");
-  if (!memoryApiUrl) missingFields.push("memoryApiUrl");
-  if (!memoryApiKey) missingFields.push("memoryApiKey");
-  if (missingFields.length > 0) issues.push(`missing ${missingFields.join(", ")}`);
+  if (!memoryModel) issues.push("missing memoryModel");
+  if (!memoryApiUrl) issues.push("missing memoryApiUrl");
+  if (!memoryApiKey) issues.push("missing memoryApiKey");
+  if (isPlaceholderApiKey(memoryApiKey)) issues.push("replace the placeholder memoryApiKey value");
 
-  if (isPlaceholderApiKey(memoryApiKey)) {
-    issues.push("replace the placeholder memoryApiKey value");
-  }
-
-  if (!memoryModel || !memoryApiUrl || !memoryApiKey || issues.length > 0) {
+  if (issues.length > 0 || !memoryModel || !memoryApiUrl || !memoryApiKey) {
     throw new Error(`External API not configured for memory provider: ${issues.join("; ")}`);
   }
 

--- a/src/services/ai/provider-config.ts
+++ b/src/services/ai/provider-config.ts
@@ -16,14 +16,6 @@ interface ProviderConfigOverrides {
   iterationTimeout?: number;
 }
 
-function requireConfiguredField(value: string | undefined, fieldName: string): string {
-  if (!value) {
-    throw new Error(`Memory provider config invariant failed: ${fieldName} is not configured`);
-  }
-
-  return value;
-}
-
 export function buildMemoryProviderConfig(
   config: MemoryProviderRuntimeConfig,
   overrides: ProviderConfigOverrides = {}
@@ -42,14 +34,10 @@ export function buildMemoryProviderConfig(
     throw new Error(`External API not configured for memory provider: ${issues.join("; ")}`);
   }
 
-  const configuredMemoryModel = requireConfiguredField(memoryModel, "memoryModel");
-  const configuredMemoryApiUrl = requireConfiguredField(memoryApiUrl, "memoryApiUrl");
-  const configuredMemoryApiKey = requireConfiguredField(memoryApiKey, "memoryApiKey");
-
   return {
-    model: configuredMemoryModel,
-    apiUrl: configuredMemoryApiUrl,
-    apiKey: configuredMemoryApiKey,
+    model: memoryModel || "",
+    apiUrl: memoryApiUrl || "",
+    apiKey: memoryApiKey || "",
     memoryTemperature: config.memoryTemperature,
     extraParams: config.memoryExtraParams,
     maxIterations: overrides.maxIterations ?? config.autoCaptureMaxIterations,

--- a/src/services/auto-capture.ts
+++ b/src/services/auto-capture.ts
@@ -2,7 +2,7 @@ import type { PluginInput } from "@opencode-ai/plugin";
 import { memoryClient } from "./client.js";
 import { getTags } from "./tags.js";
 import { log } from "./logger.js";
-import { CONFIG, hasAutoCaptureProviderConfig } from "../config.js";
+import { CONFIG } from "../config.js";
 import { userPromptManager } from "./user-prompt/user-prompt-manager.js";
 
 interface ToolCallInfo {
@@ -14,7 +14,16 @@ const MAX_TOOL_INPUT_LENGTH = 100;
 const RETRY_BASE_DELAY_MS = 2000;
 
 let isCaptureRunning = false;
-let loggedMissingProviderConfig = false;
+let hasLoggedAutoCaptureProviderConfigIssues = false;
+
+function logAutoCaptureProviderConfigIssuesOnce(issues: string[]): void {
+  if (hasLoggedAutoCaptureProviderConfigIssues) return;
+
+  log(
+    `Auto-capture skipped: configure opencodeProvider/opencodeModel or manual memory API settings. Issues: ${issues.join("; ")}.`
+  );
+  hasLoggedAutoCaptureProviderConfigIssues = true;
+}
 
 export async function performAutoCapture(
   ctx: PluginInput,
@@ -34,13 +43,8 @@ export async function performAutoCapture(
       return;
     }
 
-    if (!hasAutoCaptureProviderConfig()) {
-      if (!loggedMissingProviderConfig) {
-        log(
-          "Auto-capture skipped: configure opencodeProvider/opencodeModel or manual memory API settings with a real API key."
-        );
-        loggedMissingProviderConfig = true;
-      }
+    if (!CONFIG.autoCaptureProviderStatus.ready) {
+      logAutoCaptureProviderConfigIssuesOnce(CONFIG.autoCaptureProviderStatus.issues);
       return;
     }
 

--- a/src/services/auto-capture.ts
+++ b/src/services/auto-capture.ts
@@ -14,16 +14,6 @@ const MAX_TOOL_INPUT_LENGTH = 100;
 const RETRY_BASE_DELAY_MS = 2000;
 
 let isCaptureRunning = false;
-let hasLoggedAutoCaptureProviderConfigIssues = false;
-
-function logAutoCaptureProviderConfigIssuesOnce(issues: string[]): void {
-  if (hasLoggedAutoCaptureProviderConfigIssues) return;
-
-  log(
-    `Auto-capture skipped: configure opencodeProvider/opencodeModel or manual memory API settings. Issues: ${issues.join("; ")}.`
-  );
-  hasLoggedAutoCaptureProviderConfigIssues = true;
-}
 
 export async function performAutoCapture(
   ctx: PluginInput,
@@ -44,7 +34,6 @@ export async function performAutoCapture(
     }
 
     if (!CONFIG.autoCaptureProviderStatus.ready) {
-      logAutoCaptureProviderConfigIssuesOnce(CONFIG.autoCaptureProviderStatus.issues);
       return;
     }
 

--- a/tests/ai-provider-config.test.ts
+++ b/tests/ai-provider-config.test.ts
@@ -102,6 +102,23 @@ describe("AI provider config", () => {
     ).toThrow("replace the placeholder memoryApiKey value");
   });
 
+  it("reports each missing manual provider field before a provider request is built", () => {
+    expect(() =>
+      buildMemoryProviderConfig({
+        memoryApiKey: "sk-realish",
+      })
+    ).toThrow("missing memoryModel, memoryApiUrl");
+  });
+
+  it("requires an API key for hosted manual provider endpoints", () => {
+    expect(() =>
+      buildMemoryProviderConfig({
+        memoryModel: "gpt-4o-mini",
+        memoryApiUrl: "https://api.openai.com/v1",
+      })
+    ).toThrow("missing memoryApiKey");
+  });
+
   it("still allows no-key local OpenAI-compatible endpoints", () => {
     const providerConfig = buildMemoryProviderConfig({
       memoryModel: "local-model",

--- a/tests/ai-provider-config.test.ts
+++ b/tests/ai-provider-config.test.ts
@@ -110,26 +110,13 @@ describe("AI provider config", () => {
     ).toThrow("missing memoryModel, memoryApiUrl");
   });
 
-  it("requires an API key for hosted manual provider endpoints", () => {
+  it("requires an API key for manual provider endpoints", () => {
     expect(() =>
       buildMemoryProviderConfig({
         memoryModel: "gpt-4o-mini",
         memoryApiUrl: "https://api.openai.com/v1",
       })
     ).toThrow("missing memoryApiKey");
-  });
-
-  it("still allows no-key local OpenAI-compatible endpoints", () => {
-    const providerConfig = buildMemoryProviderConfig({
-      memoryModel: "local-model",
-      memoryApiUrl: "http://127.0.0.1:11434/v1",
-    });
-
-    expect(providerConfig).toMatchObject({
-      model: "local-model",
-      apiUrl: "http://127.0.0.1:11434/v1",
-      apiKey: undefined,
-    });
   });
 
   it("omits temperature for openai-chat when memoryTemperature is false", async () => {

--- a/tests/ai-provider-config.test.ts
+++ b/tests/ai-provider-config.test.ts
@@ -104,7 +104,7 @@ describe("AI provider config", () => {
 
   it("reports each missing manual provider field before a provider request is built", () => {
     expect(() => buildMemoryProviderConfig({})).toThrow(
-      "missing memoryModel, memoryApiUrl, memoryApiKey"
+      "missing memoryModel; missing memoryApiUrl; missing memoryApiKey"
     );
   });
 
@@ -113,7 +113,9 @@ describe("AI provider config", () => {
       buildMemoryProviderConfig({
         memoryApiKey: "sk-...",
       })
-    ).toThrow("missing memoryModel, memoryApiUrl; replace the placeholder memoryApiKey value");
+    ).toThrow(
+      "missing memoryModel; missing memoryApiUrl; replace the placeholder memoryApiKey value"
+    );
   });
 
   it("requires an API key for manual provider endpoints", () => {

--- a/tests/ai-provider-config.test.ts
+++ b/tests/ai-provider-config.test.ts
@@ -103,11 +103,17 @@ describe("AI provider config", () => {
   });
 
   it("reports each missing manual provider field before a provider request is built", () => {
+    expect(() => buildMemoryProviderConfig({})).toThrow(
+      "missing memoryModel, memoryApiUrl, memoryApiKey"
+    );
+  });
+
+  it("reports missing fields and placeholder API key together", () => {
     expect(() =>
       buildMemoryProviderConfig({
-        memoryApiKey: "sk-realish",
+        memoryApiKey: "sk-...",
       })
-    ).toThrow("missing memoryModel, memoryApiUrl");
+    ).toThrow("missing memoryModel, memoryApiUrl; replace the placeholder memoryApiKey value");
   });
 
   it("requires an API key for manual provider endpoints", () => {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -129,7 +129,7 @@ describe("config", () => {
       ).toBe(true);
     });
 
-    it("should report manual provider mode when model and API URL are configured", () => {
+    it("should report manual provider mode when model, API URL, and API key are configured", () => {
       expect(
         getAutoCaptureProviderStatus({
           ...CONFIG,
@@ -137,12 +137,12 @@ describe("config", () => {
           opencodeModel: undefined,
           memoryModel: "local-model",
           memoryApiUrl: "http://127.0.0.1:11434/v1",
-          memoryApiKey: undefined,
+          memoryApiKey: "local-api-key",
         })
       ).toEqual({ ready: true, mode: "manual", issues: [] });
     });
 
-    it("should report missing memoryApiKey for hosted manual provider URLs", () => {
+    it("should report missing memoryApiKey when model and API URL are configured without a key", () => {
       expect(
         getAutoCaptureProviderStatus({
           ...CONFIG,

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -9,8 +9,13 @@ const originalUserProfile = process.env.USERPROFILE;
 process.env.HOME = home;
 process.env.USERPROFILE = home;
 
-const { CONFIG, hasAutoCaptureProviderConfig, isConfigured, isPlaceholderApiKey } =
-  await import("../src/config.js");
+const {
+  CONFIG,
+  getAutoCaptureProviderStatus,
+  hasAutoCaptureProviderConfig,
+  isConfigured,
+  isPlaceholderApiKey,
+} = await import("../src/config.js");
 
 afterAll(() => {
   process.env.HOME = originalHome;
@@ -122,6 +127,65 @@ describe("config", () => {
           memoryApiKey: undefined,
         })
       ).toBe(true);
+    });
+
+    it("should report manual provider mode when model and API URL are configured", () => {
+      expect(
+        getAutoCaptureProviderStatus({
+          ...CONFIG,
+          opencodeProvider: undefined,
+          opencodeModel: undefined,
+          memoryModel: "local-model",
+          memoryApiUrl: "http://127.0.0.1:11434/v1",
+          memoryApiKey: undefined,
+        })
+      ).toEqual({ ready: true, mode: "manual", issues: [] });
+    });
+
+    it("should report missing memoryApiKey for hosted manual provider URLs", () => {
+      expect(
+        getAutoCaptureProviderStatus({
+          ...CONFIG,
+          opencodeProvider: undefined,
+          opencodeModel: undefined,
+          memoryModel: "gpt-4o-mini",
+          memoryApiUrl: "https://api.openai.com/v1",
+          memoryApiKey: undefined,
+        })
+      ).toEqual({
+        ready: false,
+        issues: [
+          "opencodeProvider is not configured",
+          "opencodeModel is not configured",
+          "memoryApiKey is not configured",
+        ],
+      });
+    });
+
+    it("should report each missing manual provider field independently", () => {
+      expect(
+        getAutoCaptureProviderStatus({
+          ...CONFIG,
+          opencodeProvider: undefined,
+          opencodeModel: undefined,
+          memoryModel: undefined,
+          memoryApiUrl: undefined,
+          memoryApiKey: "sk-...",
+        })
+      ).toEqual({
+        ready: false,
+        issues: [
+          "opencodeProvider is not configured",
+          "opencodeModel is not configured",
+          "memoryModel is not configured",
+          "memoryApiUrl is not configured",
+          "memoryApiKey contains a placeholder value",
+        ],
+      });
+    });
+
+    it("should expose the resolved auto-capture provider status on CONFIG", () => {
+      expect(CONFIG.autoCaptureProviderStatus).toEqual(getAutoCaptureProviderStatus(CONFIG));
     });
   });
 


### PR DESCRIPTION
## Summary

This refactors auto-capture provider readiness so invalid configuration is detected and reported from the config layer instead of being re-derived inside the auto-capture runtime path.

Changes:
- add `CONFIG.autoCaptureProviderStatus`
- add `getAutoCaptureProviderStatus()` with explicit readiness mode/issues
- report all missing/invalid provider settings independently
- move invalid auto-capture config logging to plugin startup
- make `performAutoCapture()` silently skip when provider config is not ready
- improve manual provider config errors to list missing fields
- require all three manual provider fields: `memoryModel`, `memoryApiUrl`, and `memoryApiKey`
- keep placeholder key detection for `sk-...`, `sk-ant-...`, `gsk_...`, etc.

## Why

PR #154 fixed placeholder API keys reaching provider setup, but the readiness logic still lived partly in `auto-capture.ts` and partly in provider config validation.

This follow-up makes the intended state explicit:

- OpenCode provider mode is ready when `opencodeProvider` and `opencodeModel` are configured.
- Manual provider mode is ready when `memoryModel`, `memoryApiUrl`, and a non-placeholder `memoryApiKey` are configured.
- Invalid states expose every config issue at once instead of failing one check at a time.

This also removes the runtime “log once” flag from auto-capture. The warning is now logged once naturally during plugin initialization.