### PR TITLE
fix(sqlite): avoid require in shard deletion

### DIFF
--- a/src/services/sqlite/shard-manager.ts
+++ b/src/services/sqlite/shard-manager.ts
@@ -1,6 +1,6 @@
 import { getDatabase } from "./sqlite-bootstrap.js";
 import { join, basename } from "node:path";
-import { existsSync } from "node:fs";
+import { existsSync, unlinkSync } from "node:fs";
 import { CONFIG } from "../../config.js";
 import { connectionManager } from "./connection-manager.js";
 import { log } from "../logger.js";
@@ -309,9 +309,8 @@ export class ShardManager {
       connectionManager.closeConnection(fullPath);
 
       try {
-        const fs = require("node:fs");
-        if (fs.existsSync(fullPath)) {
-          fs.unlinkSync(fullPath);
+        if (existsSync(fullPath)) {
+          unlinkSync(fullPath);
         }
       } catch (error) {
         log("Error deleting shard file", {

--- a/tests/plugin-loader-contract.test.ts
+++ b/tests/plugin-loader-contract.test.ts
@@ -27,6 +27,15 @@ describe("OpenCode 1.3.x plugin-loader contract", () => {
     );
   });
 
+  it("dist shard manager avoids CommonJS fs require in ESM output", () => {
+    const source = readFileSync(
+      new URL("../dist/services/sqlite/shard-manager.js", import.meta.url),
+      "utf-8"
+    );
+
+    expect(source).not.toMatch(/require\s*\(\s*["']node:fs["']\s*\)/);
+  });
+
   it('package.json has an exports["./server"] field', () => {
     const pkg = readPackageJson();
     const exports = pkg["exports"] as Record<string, unknown> | undefined;


### PR DESCRIPTION
## Summary
- replace the CommonJS `require("node:fs")` in `deleteShard()` with static ESM `node:fs` imports
- keep shard file cleanup working when the package is loaded as an ES module by OpenCode
- add a plugin-loader contract regression for the built shard-manager output

## Root cause
`opencode-mem` is published as `type: module`, but `deleteShard()` used a local CommonJS `require("node:fs")`. In Node/OpenCode ESM loading, that can throw `require is not defined`, leaving the shard DB file behind after metadata/index cleanup.

## Validation
- `bun install`
- `bun run build`
- `bun test tests/plugin-loader-contract.test.ts`
- `bun run typecheck`
- `bun run format:check`
- `bun test`
- `git diff --check`

Related to #117