### PR TITLE
fix(auto-capture): capture all idle prompts

### DIFF
--- a/src/services/auto-capture.ts
+++ b/src/services/auto-capture.ts
@@ -3,7 +3,7 @@ import { memoryClient } from "./client.js";
 import { getTags } from "./tags.js";
 import { log } from "./logger.js";
 import { CONFIG } from "../config.js";
-import { userPromptManager } from "./user-prompt/user-prompt-manager.js";
+import { userPromptManager, type UserPrompt } from "./user-prompt/user-prompt-manager.js";
 
 interface ToolCallInfo {
   name: string;
@@ -23,13 +23,9 @@ export async function performAutoCapture(
   if (isCaptureRunning) return;
   isCaptureRunning = true;
 
-  let claimedPromptId: string | null = null;
-  const maxRetries = CONFIG.autoCaptureMaxRetries ?? 3;
-  let attempt = 0;
-
   try {
-    const prompt = userPromptManager.getLastUncapturedPrompt(sessionID);
-    if (!prompt) {
+    const prompts = userPromptManager.getUncapturedPromptsForSession(sessionID);
+    if (prompts.length === 0) {
       return;
     }
 
@@ -37,11 +33,30 @@ export async function performAutoCapture(
       return;
     }
 
+    const maxRetries = CONFIG.autoCaptureMaxRetries ?? 3;
+    for (const prompt of prompts) {
+      await capturePrompt(ctx, sessionID, directory, prompt, maxRetries);
+    }
+  } finally {
+    isCaptureRunning = false;
+  }
+}
+
+async function capturePrompt(
+  ctx: PluginInput,
+  sessionID: string,
+  directory: string,
+  prompt: UserPrompt,
+  maxRetries: number
+): Promise<void> {
+  let claimedPromptId: string | null = null;
+  let attempt = prompt.capture_attempts || 0;
+
+  try {
     if (!userPromptManager.claimPrompt(prompt.id)) {
       return;
     }
     claimedPromptId = prompt.id;
-    attempt = prompt.capture_attempts || 0;
 
     while (attempt < maxRetries) {
       attempt++;
@@ -59,12 +74,10 @@ export async function performAutoCapture(
         }
 
         const messages = response.data;
-        const promptIndex = messages.findIndex((m: any) => m.info?.id === prompt.messageId);
-        if (promptIndex === -1) {
+        const aiMessages = getAIResponseMessages(messages, prompt.messageId);
+        if (aiMessages === null) {
           return;
         }
-
-        const aiMessages = messages.slice(promptIndex + 1);
         if (aiMessages.length === 0) {
           return;
         }
@@ -175,8 +188,19 @@ export async function performAutoCapture(
         );
       }
     }
-    isCaptureRunning = false;
   }
+}
+
+function getAIResponseMessages(messages: any[], promptMessageId: string): any[] | null {
+  const promptIndex = messages.findIndex((m: any) => m.info?.id === promptMessageId);
+  if (promptIndex === -1) return null;
+
+  const responseMessages: any[] = [];
+  for (const message of messages.slice(promptIndex + 1)) {
+    if (message.info?.role === "user") break;
+    responseMessages.push(message);
+  }
+  return responseMessages;
 }
 
 function extractAIContent(messages: any[]): {

--- a/src/services/user-prompt/user-prompt-manager.ts
+++ b/src/services/user-prompt/user-prompt-manager.ts
@@ -89,7 +89,7 @@ export class UserPromptManager {
   getLastUncapturedPrompt(sessionId: string): UserPrompt | null {
     const maxRetries = CONFIG.autoCaptureMaxRetries ?? 3;
     const stmt = this.db.prepare(`
-      SELECT * FROM user_prompts 
+      SELECT * FROM user_prompts
       WHERE session_id = ? AND captured = 0 AND capture_attempts < ?
       ORDER BY created_at DESC 
       LIMIT 1
@@ -99,6 +99,18 @@ export class UserPromptManager {
     if (!row) return null;
 
     return this.rowToPrompt(row);
+  }
+
+  getUncapturedPromptsForSession(sessionId: string): UserPrompt[] {
+    const maxRetries = CONFIG.autoCaptureMaxRetries ?? 3;
+    const stmt = this.db.prepare(`
+      SELECT * FROM user_prompts
+      WHERE session_id = ? AND captured = 0 AND capture_attempts < ?
+      ORDER BY created_at ASC
+    `);
+
+    const rows = stmt.all(sessionId, maxRetries) as any[];
+    return rows.map((row) => this.rowToPrompt(row));
   }
 
   deletePrompt(promptId: string): void {

--- a/tests/auto-capture.test.ts
+++ b/tests/auto-capture.test.ts
@@ -1,0 +1,230 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+const autoCaptureUrl = new URL("../src/services/auto-capture.js", import.meta.url).href;
+const clientUrl = new URL("../src/services/client.js", import.meta.url).href;
+const configUrl = new URL("../src/config.js", import.meta.url).href;
+const tagsUrl = new URL("../src/services/tags.js", import.meta.url).href;
+const promptManagerUrl = new URL(
+  "../src/services/user-prompt/user-prompt-manager.js",
+  import.meta.url
+).href;
+const loggerUrl = new URL("../src/services/logger.js", import.meta.url).href;
+const languageUrl = new URL("../src/services/language-detector.js", import.meta.url).href;
+const opencodeProviderUrl = new URL("../src/services/ai/opencode-provider.js", import.meta.url)
+  .href;
+
+function runScenario() {
+  const dir = mkdtempSync(join(tmpdir(), "opencode-mem-auto-capture-"));
+  tempDirs.push(dir);
+  const scriptPath = join(dir, "scenario.mjs");
+
+  const script = `
+import { mock } from "bun:test";
+
+const prompts = [
+  {
+    id: "prompt-1",
+    sessionId: "session-1",
+    messageId: "msg-1",
+    projectPath: "/workspace",
+    content: "First request",
+    createdAt: 1,
+    captured: false,
+    claimed: false,
+    capture_attempts: 0,
+  },
+  {
+    id: "prompt-2",
+    sessionId: "session-1",
+    messageId: "msg-2",
+    projectPath: "/workspace",
+    content: "Second request",
+    createdAt: 2,
+    captured: false,
+    claimed: false,
+    capture_attempts: 0,
+  },
+];
+const addCalls = [];
+const summaryPrompts = [];
+
+function pendingForSession(sessionId) {
+  return prompts
+    .filter((prompt) => prompt.sessionId === sessionId && !prompt.captured && !prompt.claimed)
+    .sort((a, b) => a.createdAt - b.createdAt);
+}
+
+mock.module(${JSON.stringify(configUrl)}, () => ({
+  CONFIG: {
+    autoCaptureMaxRetries: 1,
+    autoCaptureProviderStatus: { ready: true, mode: "opencode", issues: [] },
+    autoCaptureLanguage: "en",
+    opencodeProvider: "openai",
+    opencodeModel: "gpt-test",
+    showAutoCaptureToasts: false,
+    showErrorToasts: false,
+  },
+}));
+
+mock.module(${JSON.stringify(clientUrl)}, () => ({
+  memoryClient: {
+    listMemories: async () => ({ success: true, memories: [] }),
+    addMemory: async (content, _tag, metadata) => {
+      addCalls.push({ content, metadata });
+      return { success: true, id: \`mem-\${addCalls.length}\` };
+    },
+    close() {},
+  },
+}));
+
+mock.module(${JSON.stringify(tagsUrl)}, () => ({
+  getTags: () => ({
+    project: {
+      tag: "opencode_project_test",
+      displayName: "Test Project",
+      userName: "Test User",
+      userEmail: "test@example.com",
+      projectPath: "/workspace",
+      projectName: "workspace",
+      gitRepoUrl: undefined,
+    },
+  }),
+}));
+
+mock.module(${JSON.stringify(promptManagerUrl)}, () => ({
+  userPromptManager: {
+    getLastUncapturedPrompt(sessionId) {
+      return [...pendingForSession(sessionId)].pop() ?? null;
+    },
+    getUncapturedPromptsForSession(sessionId) {
+      return pendingForSession(sessionId);
+    },
+    claimPrompt(id) {
+      const prompt = prompts.find((item) => item.id === id);
+      if (!prompt || prompt.captured || prompt.claimed) return false;
+      prompt.claimed = true;
+      return true;
+    },
+    recordFailedAttempt(id) {
+      const prompt = prompts.find((item) => item.id === id);
+      if (prompt) prompt.capture_attempts += 1;
+    },
+    releaseClaim(id) {
+      const prompt = prompts.find((item) => item.id === id);
+      if (!prompt || !prompt.claimed || prompt.captured) return false;
+      prompt.claimed = false;
+      return true;
+    },
+    linkMemoryToPrompt(id, memoryId) {
+      const prompt = prompts.find((item) => item.id === id);
+      if (prompt) prompt.linkedMemoryId = memoryId;
+    },
+    markAsCaptured(id) {
+      const prompt = prompts.find((item) => item.id === id);
+      if (prompt) {
+        prompt.captured = true;
+        prompt.claimed = false;
+      }
+    },
+    deletePrompt(id) {
+      const prompt = prompts.find((item) => item.id === id);
+      if (prompt) {
+        prompt.captured = true;
+        prompt.claimed = false;
+        prompt.deleted = true;
+      }
+    },
+  },
+}));
+
+mock.module(${JSON.stringify(loggerUrl)}, () => ({ log: () => {} }));
+mock.module(${JSON.stringify(languageUrl)}, () => ({
+  detectLanguage: () => "en",
+  getLanguageName: () => "English",
+}));
+mock.module(${JSON.stringify(opencodeProviderUrl)}, () => ({
+  isProviderConnected: () => true,
+  getV2Client: () => ({}),
+  generateStructuredOutput: async ({ userPrompt }) => {
+    summaryPrompts.push(userPrompt);
+    return {
+      summary: userPrompt.includes("First request") ? "summary-first" : "summary-second",
+      type: "discussion",
+      tags: [],
+    };
+  },
+}));
+
+const { performAutoCapture } = await import(${JSON.stringify(autoCaptureUrl)});
+await performAutoCapture(
+  {
+    client: {
+      session: {
+        messages: async () => ({
+          data: [
+            { info: { id: "msg-1", role: "user" }, parts: [{ type: "text", text: "First request" }] },
+            { info: { id: "assistant-1", role: "assistant" }, parts: [{ type: "text", text: "First response" }] },
+            { info: { id: "msg-2", role: "user" }, parts: [{ type: "text", text: "Second request" }] },
+            { info: { id: "assistant-2", role: "assistant" }, parts: [{ type: "text", text: "Second response" }] },
+          ],
+        }),
+      },
+      tui: { showToast: async () => ({}) },
+    },
+  },
+  "session-1",
+  "/workspace"
+);
+
+console.log(
+  JSON.stringify({
+    addPromptIds: addCalls.map((call) => call.metadata.promptId),
+    summaries: addCalls.map((call) => call.content),
+    summaryPrompts,
+  })
+);
+`;
+
+  writeFileSync(scriptPath, script);
+
+  const result = Bun.spawnSync({
+    cmd: [process.execPath, scriptPath],
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const stdout = Buffer.from(result.stdout).toString("utf8").trim();
+  const stderr = Buffer.from(result.stderr).toString("utf8").trim();
+
+  return {
+    exitCode: result.exitCode,
+    stdout,
+    stderr,
+    parsed: stdout ? JSON.parse(stdout) : null,
+  };
+}
+
+describe("auto-capture idle processing", () => {
+  it("captures all uncaptured prompts in a session in chronological response windows", () => {
+    const result = runScenario();
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.parsed?.addPromptIds).toEqual(["prompt-1", "prompt-2"]);
+    expect(result.parsed?.summaries).toEqual(["summary-first", "summary-second"]);
+    expect(result.parsed?.summaryPrompts[0]).toContain("First response");
+    expect(result.parsed?.summaryPrompts[0]).not.toContain("Second response");
+    expect(result.parsed?.summaryPrompts[1]).toContain("Second response");
+  });
+});

--- a/tests/user-prompt-manager-claim.test.ts
+++ b/tests/user-prompt-manager-claim.test.ts
@@ -58,6 +58,16 @@ describe("UserPromptManager.claimPrompt / releaseClaim", () => {
     return raw?.captured ?? -1;
   }
 
+  function setCreatedAt(id: string, createdAt: number): void {
+    (
+      mgr as unknown as {
+        db: { prepare: (s: string) => { run: (...args: unknown[]) => unknown } };
+      }
+    ).db
+      .prepare(`UPDATE user_prompts SET created_at = ? WHERE id = ?`)
+      .run(createdAt, id);
+  }
+
   function newPrompt(sessionId = "session-test", content = "hello") {
     const id = mgr.savePrompt(
       sessionId,
@@ -124,5 +134,27 @@ describe("UserPromptManager.claimPrompt / releaseClaim", () => {
 
     const prompt = mgr.getLastUncapturedPrompt("session-retries");
     expect(prompt).toBeNull();
+  });
+
+  it("returns all uncaptured prompts for a session oldest first", () => {
+    const later = newPrompt("session-batch", "later");
+    const older = newPrompt("session-batch", "older");
+    const captured = newPrompt("session-batch", "captured");
+    const otherSession = newPrompt("session-other", "other");
+    const retriedOut = newPrompt("session-batch", "retried out");
+
+    setCreatedAt(later, 20);
+    setCreatedAt(older, 10);
+    setCreatedAt(captured, 15);
+    setCreatedAt(otherSession, 5);
+    setCreatedAt(retriedOut, 25);
+    mgr.markAsCaptured(captured);
+    for (let i = 0; i < 4; i++) {
+      mgr.recordFailedAttempt(retriedOut);
+    }
+
+    const prompts = mgr.getUncapturedPromptsForSession("session-batch");
+
+    expect(prompts.map((prompt) => prompt.id)).toEqual([older, later]);
   });
 });


### PR DESCRIPTION
## Summary
- Process every uncaptured prompt for the idle session in chronological order instead of only the latest one.
- Scope each auto-capture summary to the assistant/tool messages before the next user prompt.
- Add regression coverage for multi-prompt idle capture and session-scoped prompt ordering.

Fixes #159

## Validation
- bun test tests/auto-capture.test.ts tests/user-prompt-manager-claim.test.ts
- bun run typecheck
- bun run build
- bun test
- bun run format:check
- git diff --check