### PR TITLE
Prevent duplicate prompt rows on repeated delivery

### DIFF
--- a/src/services/user-prompt/user-prompt-manager.ts
+++ b/src/services/user-prompt/user-prompt-manager.ts
@@ -93,11 +93,35 @@ export class UserPromptManager {
 
     const stmt = this.db.prepare(`
       INSERT INTO user_prompts (id, session_id, message_id, project_path, content, created_at, captured)
-      VALUES (?, ?, ?, ?, ?, ?, 0)
+      SELECT ?, ?, ?, ?, ?, ?, 0
+      WHERE NOT EXISTS (
+        SELECT 1 FROM user_prompts WHERE session_id = ? AND message_id = ?
+      )
     `);
 
-    stmt.run(id, sessionId, messageId, projectPath, content, now);
-    return id;
+    const result = stmt.run(
+      id,
+      sessionId,
+      messageId,
+      projectPath,
+      content,
+      now,
+      sessionId,
+      messageId
+    );
+    if (result.changes > 0) return id;
+
+    const existing = this.db
+      .prepare(
+        `SELECT id FROM user_prompts
+         WHERE session_id = ? AND message_id = ?
+         ORDER BY created_at ASC
+         LIMIT 1`
+      )
+      .get(sessionId, messageId) as { id: string } | undefined;
+    if (existing) return existing.id;
+
+    throw new Error("Failed to save or locate user prompt");
   }
 
   setPromptModel(messageId: string, providerId: string, modelId: string): void {

--- a/tests/user-prompt-manager-claim.test.ts
+++ b/tests/user-prompt-manager-claim.test.ts
@@ -127,6 +127,7 @@ describe("UserPromptManager.claimPrompt / releaseClaim", () => {
 
   it("ignores prompts that have exceeded max retries", () => {
     const id = mgr.savePrompt("session-retries", "msg-1", "/path", "hello retry");
+    activeIds.push(id);
 
     for (let i = 0; i < 4; i++) {
       mgr.recordFailedAttempt(id);
@@ -156,5 +157,54 @@ describe("UserPromptManager.claimPrompt / releaseClaim", () => {
     const prompts = mgr.getUncapturedPromptsForSession("session-batch");
 
     expect(prompts.map((prompt) => prompt.id)).toEqual([older, later]);
+  });
+
+  it("stores repeated delivery of the same session message only once", () => {
+    const first = mgr.savePrompt(
+      "session-duplicate",
+      "message-duplicate",
+      "/tmp/proj",
+      "same prompt"
+    );
+    const second = mgr.savePrompt(
+      "session-duplicate",
+      "message-duplicate",
+      "/tmp/proj",
+      "same prompt"
+    );
+    activeIds.push(first, second);
+
+    expect(second).toBe(first);
+    expect(mgr.countUnanalyzedForUserLearning()).toBe(1);
+  });
+
+  it("does not reopen profile learning when a handled message is delivered again", () => {
+    const first = mgr.savePrompt(
+      "session-handled",
+      "message-handled",
+      "/tmp/proj",
+      "already learned"
+    );
+    mgr.markAsUserLearningCaptured(first);
+
+    const repeated = mgr.savePrompt(
+      "session-handled",
+      "message-handled",
+      "/tmp/proj",
+      "already learned"
+    );
+    activeIds.push(first, repeated);
+
+    expect(repeated).toBe(first);
+    expect(mgr.countUnanalyzedForUserLearning()).toBe(0);
+  });
+
+  it("keeps the same message id distinct across sessions", () => {
+    const first = mgr.savePrompt("session-one", "shared-message", "/tmp/proj", "first session");
+    const second = mgr.savePrompt("session-two", "shared-message", "/tmp/proj", "second session");
+    activeIds.push(first, second);
+
+    expect(second).not.toBe(first);
+    expect(mgr.countUnanalyzedForUserLearning()).toBe(2);
   });
 });


### PR DESCRIPTION
## What changed

`chat.message` can deliver the same session message more than once. Previously,
each `savePrompt()` call created a new row, so one logical prompt could be
counted multiple times by profile learning.

This makes prompt persistence idempotent for each `(session_id, message_id)`
pair and returns the existing prompt id on repeated delivery. It preserves the
row's existing capture state and still treats the same message id in different
sessions as separate prompts.

This does not remove historical duplicate rows or change profile-learning
timing; it prevents new duplicates from this delivery path.

## Verification

- focused regression suite: 11 passed
- full test suite: 202 passed
- `bun run typecheck`
- `bun run format:check`
- `bun run build`

Addresses #170
