### PR TITLE
chore: release v2.20.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-mem",
-  "version": "2.19.4",
+  "version": "2.20.0",
   "description": "OpenCode plugin that gives coding agents persistent memory using local vector database",
   "type": "module",
   "main": "dist/plugin.js",


### PR DESCRIPTION
## Release

Includes the verified batch merge of PRs #181, #178, #175, and #171.

Local verification on the fully merged tree:
- `bun install --frozen-lockfile`
- `bun run typecheck`
- `bun run build`
- `bun test` — 226 pass, 0 fail

Version-only change: `2.19.4` → `2.20.0`.