### PR TITLE
fix(user-memory-learning): gate profile analysis on provider readiness

### DIFF
--- a/src/services/user-memory-learning.ts
+++ b/src/services/user-memory-learning.ts
@@ -16,6 +16,12 @@ export async function performUserProfileLearning(
   directory: string
 ): Promise<void> {
   if (isLearningRunning) return;
+  if (!CONFIG.autoCaptureProviderStatus || !CONFIG.autoCaptureProviderStatus.ready) {
+    log("user-profile-learning: skipped (provider not ready)", {
+      issues: CONFIG.autoCaptureProviderStatus?.issues ?? ["status undefined"],
+    });
+    return;
+  }
   isLearningRunning = true;
   try {
     const count = userPromptManager.countUnanalyzedForUserLearning();


### PR DESCRIPTION
Fixes #176 (partial)

## What this addresses

The recursive re-ingestion loop in `performUserProfileLearning`. The existing function dispatches an LLM call but lacks the `autoCaptureProviderStatus.ready` guard that `auto-capture.ts:33` already uses. When the profile-analysis provider is not ready, the LLM call throws and the function exits without marking the just-fetched prompts as captured, so the same row set re-triggers the threshold check on every session idle forever.

This PR covers the **failure mode** for unready providers. The related **recursion via re-ingested analysis prompts** (the core of #176's suggested fixes 1 and 2) is not addressed here — see the other open PRs in this series.

## Changes
- `src/services/user-memory-learning.ts` (+6): add the `!ready` guard at the top of `performUserProfileLearning`, mirroring `auto-capture.ts:33`. Log and return early.

## Verification
- `bun run typecheck` — clean
- `bun run build` — clean
- `bunx prettier --check` — clean

## Manual check
With `getAutoCaptureProviderStatus()` returning `{ ready: false, issues: [...] }` (e.g. an unconfigured provider), calling `performUserProfileLearning` should log `user-profile-learning: skipped (provider not ready)` and return immediately, without dispatching the LLM call.

## Background
See #issuecomment-5033470016 for the full analysis this is based on.