### PR TITLE
fix(user-profile-analysis): cap context sent to profile LLM

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ The plugin creates a full commented template at this path on first startup. This
   "showErrorToasts": true,
 
   "userProfileAnalysisInterval": 10,
+  "userProfileMaxContextBytes": 32768,
   "maxMemories": 10,
 
   "compaction": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -60,6 +60,7 @@ interface OpenCodeMemConfig {
   deduplicationEnabled?: boolean;
   deduplicationSimilarityThreshold?: number;
   userProfileAnalysisInterval?: number;
+  userProfileMaxContextBytes?: number;
   userProfileDisplayPreferences?: number;
   userProfileDisplayPatterns?: number;
   userProfileDisplayWorkflows?: number;
@@ -152,6 +153,7 @@ const DEFAULTS: Required<
   deduplicationEnabled: true,
   deduplicationSimilarityThreshold: 0.9,
   userProfileAnalysisInterval: 10,
+  userProfileMaxContextBytes: 32768,
   userProfileDisplayPreferences: 20,
   userProfileDisplayPatterns: 15,
   userProfileDisplayWorkflows: 10,
@@ -597,6 +599,8 @@ function buildConfig(fileConfig: OpenCodeMemConfig) {
       fileConfig.deduplicationSimilarityThreshold ?? DEFAULTS.deduplicationSimilarityThreshold,
     userProfileAnalysisInterval:
       fileConfig.userProfileAnalysisInterval ?? DEFAULTS.userProfileAnalysisInterval,
+    userProfileMaxContextBytes:
+      fileConfig.userProfileMaxContextBytes ?? DEFAULTS.userProfileMaxContextBytes,
     userProfileDisplayPreferences:
       fileConfig.userProfileDisplayPreferences ?? DEFAULTS.userProfileDisplayPreferences,
     userProfileDisplayPatterns:

--- a/src/services/user-memory-learning.ts
+++ b/src/services/user-memory-learning.ts
@@ -355,10 +355,15 @@ CRITICAL: Only output observations grounded in the RECENT PROMPTS above. Write d
 - "User analyzes problems and verifies solutions" (too abstract — not a concrete step sequence)
 - "User writes code and tests it" (too generic — covers everything)`;
 
+  const maxBytes = CONFIG.userProfileMaxContextBytes ?? 32768;
+  const truncate = (s: string) =>
+    s.length > maxBytes
+      ? s.substring(0, maxBytes) + "\n[... context truncated to userProfileMaxContextBytes ...]"
+      : s;
   if (validationPrompt) {
-    return base + "\n\n" + validationPrompt;
+    return truncate(base + "\n\n" + validationPrompt);
   }
-  return base;
+  return truncate(base);
 }
 
 type AnalysisResult = { raw: UserProfileData; merged: UserProfileData | null };


### PR DESCRIPTION
Fixes #176 (partial)

## What this addresses

Item #3 of the suggested fixes in #176: cap the total assembled prompt size that `buildUserAnalysisContext` ships to the profile-analysis LLM. Today the function concatenates the template + all N user prompts with no size guard, so a single oversized prompt or a large backlog can push the payload past the model window.

This PR adds the total-size cap (default 32 KB). It does **not** add the per-item cap or skip-analysis-prompt logic from items #1 and #2 — those are a separate, deeper surgery on the `prompts.map((p, i) => \`${i + 1}. ${p.content}\`).join("\n\n")` line and will come as a follow-up if there is interest.

## Changes
- `src/services/user-memory-learning.ts` (+9/-2): introduce a local `truncate(s)` helper and apply it to both branches (`base` alone, and `base + validationPrompt`).
- `src/config.ts` (+4): new optional knob `userProfileMaxContextBytes` wired through `OpenCodeMemConfig`, `DEFAULTS`, and `buildConfig` in the same shape as `userProfileAnalysisInterval`.
- `README.md` (+1): added the new field to the Configuration Essentials example block.

## Verification
- `bun run typecheck` — clean
- `bun run build` — clean
- `bunx prettier --check` — clean

## Manual check
Set `userProfileMaxContextBytes: 1024` in `~/.config/opencode/opencode-mem.jsonc` and trigger a profile analysis with enough prompts to exceed 1 KB. The LLM payload should be truncated and include the marker `[... context truncated to userProfileMaxContextBytes ...]`.

## Background
See #issuecomment-5033470016 for the full analysis this is based on.