### PR TITLE
fix(cleanup): reclaim disk via VACUUM after retention cleanup

### DIFF
--- a/src/services/cleanup-service.ts
+++ b/src/services/cleanup-service.ts
@@ -4,6 +4,8 @@ import { connectionManager } from "./sqlite/connection-manager.js";
 import { CONFIG } from "../config.js";
 import { log } from "./logger.js";
 import { userPromptManager } from "./user-prompt/user-prompt-manager.js";
+import Database from "bun:sqlite";
+import { join } from "node:path";
 
 interface CleanupResult {
   deletedCount: number;
@@ -104,6 +106,16 @@ export class CleanupService {
       }
 
       const promptsDeleted = promptCleanupResult.deleted - linkedMemoryIds.size;
+
+      try {
+        const promptsDbPath = join(CONFIG.storagePath, "user-prompts.db");
+        const vacuumDb = new Database(promptsDbPath, { readonly: false, create: false });
+        vacuumDb.exec("VACUUM;");
+        vacuumDb.close();
+        log("Cleanup: VACUUM done", { db: promptsDbPath });
+      } catch (err) {
+        log("Cleanup: VACUUM skipped (DB busy)", { error: String(err) });
+      }
 
       return {
         deletedCount: totalDeleted,


### PR DESCRIPTION
Fixes #176 (partial)

## What this addresses

The disk-bloat symptom of #176. `runCleanup` in `src/services/cleanup-service.ts` deletes old rows from `user-prompts.db` via `deleteOldPrompts` but never reclaims the freed pages. SQLite marks pages free but the file size does not shrink; nothing in the repo currently issues `VACUUM`. Over many cleanup cycles the DB grows monotonically.

This PR adds a best-effort VACUUM at the end of `runCleanup`. It is **not** one of the four suggested fixes in #176 (those target the recursion and the changelog-snapshot bloat). This is a related, independent reclaim that addresses the same class of "DB grows unbounded" symptom from a different angle.

## Changes
- `src/services/cleanup-service.ts` (+12): two new imports (`Database from "bun:sqlite"`, `join from "node:path"`) and a try/catch `VACUUM` block after the cleanup loop completes. Open a fresh handle, run `VACUUM;`, close. If opencode holds the file open the call throws and we log `Cleanup: VACUUM skipped (DB busy)` without failing the cleanup result.

The cleanup service is throttled to once per day via `shouldRunCleanup()`, so VACUUM also runs at most daily.

## Verification
- `bun run typecheck` — clean
- `bun run build` — clean
- `bunx prettier --check` — clean

## Manual check
1. Let `user-prompts.db` grow past several MB (e.g. seed rows or lower `autoCleanupRetentionDays`).
2. Trigger or wait for `runCleanup`.
3. The file size should shrink after cleanup completes; the log should contain `Cleanup: VACUUM done`. If opencode currently holds the DB open, the log shows `Cleanup: VACUUM skipped (DB busy)` and size is unchanged.

## Background
See #issuecomment-5033470016 for the full analysis this is based on.