### PR TITLE
chore: release v2.20.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-mem",
-  "version": "2.20.0",
+  "version": "2.20.1",
   "description": "OpenCode plugin that gives coding agents persistent memory using local vector database",
   "type": "module",
   "main": "dist/plugin.js",


### PR DESCRIPTION
## Release

Includes the verified batch merge of PRs #187, #186, #185, and #180.

Local verification on the fully merged tree:
- `bun install --frozen-lockfile`
- `bun run typecheck`
- `bun run build`
- `bun test` — 230 pass, 0 fail

Version-only change: `2.20.0` → `2.20.1`.