### PR TITLE
chore: release v2.21.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-mem",
-  "version": "2.20.1",
+  "version": "2.21.0",
   "description": "OpenCode plugin that gives coding agents persistent memory using local Turso/libSQL vector search",
   "type": "module",
   "main": "dist/plugin.js",


### PR DESCRIPTION
## Release

Includes the verified batch merge of PRs #195, #194, #193, #192, #191, #190, and #179.

Highlights:
- Turso/libSQL persistence and native vector search migration with legacy migration coverage
- OpenCode `inherit` model resolution fixes
- Profile-learning and AI-cleanup fixes
- Documentation improvements

Local verification on the fully merged tree:
- `bun install --frozen-lockfile`
- `bun run typecheck`
- `bun run build`
- `bun test` — 268 pass, 0 fail

Version-only change: `2.20.1` → `2.21.0`.