### PR TITLE
ci: build artifacts before package smoke tests

### DIFF
--- a/.github/workflows/platform-smoke.yml
+++ b/.github/workflows/platform-smoke.yml
@@ -43,11 +43,11 @@ jobs:
       - name: Typecheck source
         run: bun run typecheck
 
-      - name: Run test suite
-        run: bun test
-
       - name: Build package artifacts
         run: bun run build
+
+      - name: Run test suite
+        run: bun test
 
       - name: Pack and install published package shape
         shell: bash

--- a/.github/workflows/platform-smoke.yml
+++ b/.github/workflows/platform-smoke.yml
@@ -64,14 +64,17 @@ jobs:
 
           cd "$smoke_dir"
           npm init -y
+          # npm ignores overrides declared by installed dependencies, so mirror the plugin's
+          # native-runtime pin at the temporary root used by this package smoke test.
           override_version=$(node --input-type=module -e '
             import { readFileSync } from "node:fs";
             import { resolve } from "node:path";
             const pkg = JSON.parse(readFileSync(resolve(process.env.GITHUB_WORKSPACE, "package.json"), "utf8"));
             process.stdout.write(pkg.overrides?.["onnxruntime-node"] ?? "");
           ')
-          test -n "$override_version"
-          npm pkg set "overrides.onnxruntime-node=$override_version"
+          if [ -n "$override_version" ]; then
+            npm pkg set "overrides.onnxruntime-node=$override_version"
+          fi
           npm install --ignore-scripts "$tarball_path"
           cp "$GITHUB_WORKSPACE/scripts/native-deps-smoke.mjs" ./native-deps-smoke.mjs
           cp "$GITHUB_WORKSPACE/scripts/verify-libsql-vector.mjs" ./verify-libsql-vector.mjs

--- a/.github/workflows/platform-smoke.yml
+++ b/.github/workflows/platform-smoke.yml
@@ -24,7 +24,7 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
-          - macos-13
+          - macos-15-intel
           - macos-15
 
     steps:

--- a/.github/workflows/platform-smoke.yml
+++ b/.github/workflows/platform-smoke.yml
@@ -64,6 +64,14 @@ jobs:
 
           cd "$smoke_dir"
           npm init -y
+          override_version=$(node --input-type=module -e '
+            import { readFileSync } from "node:fs";
+            import { resolve } from "node:path";
+            const pkg = JSON.parse(readFileSync(resolve(process.env.GITHUB_WORKSPACE, "package.json"), "utf8"));
+            process.stdout.write(pkg.overrides?.["onnxruntime-node"] ?? "");
+          ')
+          test -n "$override_version"
+          npm pkg set "overrides.onnxruntime-node=$override_version"
           npm install --ignore-scripts "$tarball_path"
           cp "$GITHUB_WORKSPACE/scripts/native-deps-smoke.mjs" ./native-deps-smoke.mjs
           cp "$GITHUB_WORKSPACE/scripts/verify-libsql-vector.mjs" ./verify-libsql-vector.mjs

--- a/scripts/verify-libsql-vector.mjs
+++ b/scripts/verify-libsql-vector.mjs
@@ -1,30 +1,77 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { rmSync } from "node:fs";
-import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { setTimeout as delay } from "node:timers/promises";
 import { createClient } from "@libsql/client";
 
-const dbPath = join(tmpdir(), `opencode-mem-libsql-smoke-${process.pid}-${Date.now()}.db`);
-const client = createClient({ url: `file:${dbPath}` });
+const CHILD_DB_PATH_ENV = "OPENCODE_MEM_LIBSQL_SMOKE_CHILD_DB_PATH";
+const FILE_LOCK_RETRY_DELAYS_MS = [10, 25, 50, 100, 200, 400, 800];
+const RETRYABLE_FILE_LOCK_CODES = new Set(["EBUSY", "EPERM", "EACCES"]);
 
-try {
-  await client.batch(
-    [
-      "CREATE TABLE vectors (id INTEGER PRIMARY KEY, vector F32_BLOB(4) NOT NULL)",
-      "CREATE INDEX vectors_idx ON vectors (libsql_vector_idx(vector, 'metric=cosine'))",
-      "INSERT INTO vectors (vector) VALUES (vector32('[1,0,0,0]'))",
-    ],
-    "write"
-  );
-  const result = await client.execute(
-    "SELECT id FROM vector_top_k('vectors_idx', vector32('[1,0,0,0]'), 1)"
-  );
-  assert.equal(result.rows.length, 1, "vector_top_k must return the inserted vector");
-  assert.equal(Number(result.rows[0]?.id), 1, "vector_top_k must return the expected row");
-  console.log("libSQL vector smoke test passed");
-} finally {
-  client.close();
+async function verifyLibsqlVector(dbPath) {
+  const client = createClient({ url: `file:${dbPath}` });
+  try {
+    await client.batch(
+      [
+        "CREATE TABLE vectors (id INTEGER PRIMARY KEY, vector F32_BLOB(4) NOT NULL)",
+        "CREATE INDEX vectors_idx ON vectors (libsql_vector_idx(vector, 'metric=cosine'))",
+        "INSERT INTO vectors (vector) VALUES (vector32('[1,0,0,0]'))",
+      ],
+      "write"
+    );
+    const result = await client.execute(
+      "SELECT id FROM vector_top_k('vectors_idx', vector32('[1,0,0,0]'), 1)"
+    );
+    assert.equal(result.rows.length, 1, "vector_top_k must return the inserted vector");
+    assert.equal(Number(result.rows[0]?.id), 1, "vector_top_k must return the expected row");
+    console.log("libSQL vector smoke test passed");
+  } finally {
+    client.close();
+  }
+}
+
+async function removeDatabaseFiles(dbPath) {
   for (const suffix of ["", "-shm", "-wal"]) {
-    rmSync(`${dbPath}${suffix}`, { force: true });
+    const path = `${dbPath}${suffix}`;
+    for (let attempt = 0; ; attempt += 1) {
+      try {
+        rmSync(path, { force: true });
+        break;
+      } catch (error) {
+        const code = error?.code;
+        if (
+          attempt >= FILE_LOCK_RETRY_DELAYS_MS.length ||
+          !RETRYABLE_FILE_LOCK_CODES.has(code)
+        ) {
+          throw error;
+        }
+        await delay(FILE_LOCK_RETRY_DELAYS_MS[attempt]);
+      }
+    }
+  }
+}
+
+const childDbPath = process.env[CHILD_DB_PATH_ENV];
+if (childDbPath) {
+  await verifyLibsqlVector(childDbPath);
+} else {
+  const dbPath = join(tmpdir(), `opencode-mem-libsql-smoke-${process.pid}-${Date.now()}.db`);
+  const child = spawnSync(process.execPath, [fileURLToPath(import.meta.url)], {
+    env: { ...process.env, [CHILD_DB_PATH_ENV]: dbPath },
+    stdio: "inherit",
+  });
+
+  try {
+    if (child.error) throw child.error;
+    if (child.status !== 0) {
+      throw new Error(
+        `libSQL vector smoke child exited with ${child.signal ?? `status ${child.status}`}`
+      );
+    }
+  } finally {
+    await removeDatabaseFiles(dbPath);
   }
 }

--- a/src/services/migration-service.ts
+++ b/src/services/migration-service.ts
@@ -9,6 +9,7 @@ import { log } from "./logger.js";
 import { formatTagsForEmbedding } from "./turso/vector-utils.js";
 import type { MemoryRecord, ShardInfo } from "./turso/types.js";
 import { acquireTursoOperationLock } from "./turso/operation-lock.js";
+import { withSqliteFileLockRetry } from "./turso/sqlite-handle-release.js";
 
 export interface DimensionMismatch {
   needsMigration: boolean;
@@ -349,11 +350,11 @@ export class MigrationService {
         "utf-8"
       );
       await tursoConnectionManager.closeConnection(shard.dbPath);
-      renameSync(shard.dbPath, backupPath);
+      await withSqliteFileLockRetry(() => renameSync(shard.dbPath, backupPath));
       try {
-        renameSync(stagedPath, shard.dbPath);
+        await withSqliteFileLockRetry(() => renameSync(stagedPath, shard.dbPath));
       } catch (error) {
-        renameSync(backupPath, shard.dbPath);
+        await withSqliteFileLockRetry(() => renameSync(backupPath, shard.dbPath));
         throw error;
       }
 
@@ -368,7 +369,7 @@ export class MigrationService {
     } catch (error) {
       await tursoConnectionManager.closeConnection(stagedPath);
       if (existsSync(stagedPath)) {
-        unlinkSync(stagedPath);
+        await withSqliteFileLockRetry(() => unlinkSync(stagedPath));
       }
       if (existsSync(swapStatePath) && existsSync(shard.dbPath)) {
         unlinkSync(swapStatePath);

--- a/src/services/tags.ts
+++ b/src/services/tags.ts
@@ -109,7 +109,9 @@ export function getGitCommonDir(directory: string): string | null {
       : normalize(resolve(directory, commonDir));
 
     if (existsSync(resolved)) {
-      return realpathSync(resolved);
+      const canonical =
+        process.platform === "win32" ? realpathSync.native(resolved) : realpathSync(resolved);
+      return normalize(canonical);
     }
 
     return resolved;

--- a/src/services/turso/connection-manager.ts
+++ b/src/services/turso/connection-manager.ts
@@ -3,15 +3,8 @@ import { existsSync, mkdirSync } from "node:fs";
 import { dirname, resolve, relative, isAbsolute, sep } from "node:path";
 import { CONFIG } from "../../config.js";
 import { log } from "../logger.js";
+import { collectReleasedSqliteHandles } from "./sqlite-handle-release.js";
 import { TursoDb } from "./turso-db.js";
-
-const WINDOWS_FILE_HANDLE_SETTLE_MS = 100;
-
-async function waitForWindowsFileHandleRelease(): Promise<void> {
-  if (process.platform === "win32") {
-    await new Promise<void>((resolve) => setTimeout(resolve, WINDOWS_FILE_HANDLE_SETTLE_MS));
-  }
-}
 
 function toFileUrl(dbPath: string): string {
   return dbPath.startsWith("file:") ? dbPath : `file:${dbPath}`;
@@ -94,7 +87,7 @@ export class TursoConnectionManager {
       this.connections.delete(dbPath);
     }
 
-    await waitForWindowsFileHandleRelease();
+    await collectReleasedSqliteHandles();
   }
 
   async closeAll(): Promise<void> {
@@ -111,7 +104,7 @@ export class TursoConnectionManager {
       }
       this.connections.clear();
       this.pending.clear();
-      await waitForWindowsFileHandleRelease();
+      await collectReleasedSqliteHandles();
     })();
 
     try {

--- a/src/services/turso/connection-manager.ts
+++ b/src/services/turso/connection-manager.ts
@@ -23,11 +23,16 @@ function assertPathInsideStorage(dbPath: string): void {
 export class TursoConnectionManager {
   private readonly connections = new Map<string, TursoDb>();
   private readonly pending = new Map<string, Promise<TursoDb>>();
+  private readonly closingConnections = new Map<string, Promise<void>>();
   private closingPromise: Promise<void> | null = null;
 
   async getConnection(dbPath: string): Promise<TursoDb> {
     if (this.closingPromise) {
       await this.closingPromise;
+    }
+    const closingConnection = this.closingConnections.get(dbPath);
+    if (closingConnection) {
+      await closingConnection;
     }
     assertPathInsideStorage(dbPath);
 
@@ -76,25 +81,47 @@ export class TursoConnectionManager {
   }
 
   async closeConnection(dbPath: string): Promise<void> {
-    const db = this.connections.get(dbPath);
-    if (db) {
-      try {
-        await db.close();
-      } catch (error) {
-        log("Error closing Turso database", { path: dbPath, error: String(error) });
-      }
-
-      this.connections.delete(dbPath);
+    if (this.closingPromise) {
+      await this.closingPromise;
+    }
+    const existingClose = this.closingConnections.get(dbPath);
+    if (existingClose) {
+      return existingClose;
     }
 
-    await collectReleasedSqliteHandles();
+    const closePromise = Promise.resolve()
+      .then(async () => {
+        const pending = this.pending.get(dbPath);
+        if (pending) {
+          await Promise.allSettled([pending]);
+        }
+
+        const db = this.connections.get(dbPath);
+        if (db) {
+          try {
+            await db.close();
+          } catch (error) {
+            log("Error closing Turso database", { path: dbPath, error: String(error) });
+          }
+
+          this.connections.delete(dbPath);
+        }
+
+        await collectReleasedSqliteHandles();
+      })
+      .finally(() => {
+        this.closingConnections.delete(dbPath);
+      });
+
+    this.closingConnections.set(dbPath, closePromise);
+    return closePromise;
   }
 
   async closeAll(): Promise<void> {
     if (this.closingPromise) return this.closingPromise;
 
     this.closingPromise = (async () => {
-      await Promise.allSettled(this.pending.values());
+      await Promise.allSettled([...this.pending.values(), ...this.closingConnections.values()]);
       for (const [path, db] of this.connections) {
         try {
           await db.close();

--- a/src/services/turso/connection-manager.ts
+++ b/src/services/turso/connection-manager.ts
@@ -5,6 +5,14 @@ import { CONFIG } from "../../config.js";
 import { log } from "../logger.js";
 import { TursoDb } from "./turso-db.js";
 
+const WINDOWS_FILE_HANDLE_SETTLE_MS = 100;
+
+async function waitForWindowsFileHandleRelease(): Promise<void> {
+  if (process.platform === "win32") {
+    await new Promise<void>((resolve) => setTimeout(resolve, WINDOWS_FILE_HANDLE_SETTLE_MS));
+  }
+}
+
 function toFileUrl(dbPath: string): string {
   return dbPath.startsWith("file:") ? dbPath : `file:${dbPath}`;
 }
@@ -76,15 +84,17 @@ export class TursoConnectionManager {
 
   async closeConnection(dbPath: string): Promise<void> {
     const db = this.connections.get(dbPath);
-    if (!db) return;
+    if (db) {
+      try {
+        await db.close();
+      } catch (error) {
+        log("Error closing Turso database", { path: dbPath, error: String(error) });
+      }
 
-    try {
-      await db.close();
-    } catch (error) {
-      log("Error closing Turso database", { path: dbPath, error: String(error) });
+      this.connections.delete(dbPath);
     }
 
-    this.connections.delete(dbPath);
+    await waitForWindowsFileHandleRelease();
   }
 
   async closeAll(): Promise<void> {
@@ -101,6 +111,7 @@ export class TursoConnectionManager {
       }
       this.connections.clear();
       this.pending.clear();
+      await waitForWindowsFileHandleRelease();
     })();
 
     try {

--- a/src/services/turso/connection-manager.ts
+++ b/src/services/turso/connection-manager.ts
@@ -26,6 +26,8 @@ export class TursoConnectionManager {
   private readonly closingConnections = new Map<string, Promise<void>>();
   private closingPromise: Promise<void> | null = null;
 
+  constructor(private readonly clientFactory: typeof createClient = createClient) {}
+
   async getConnection(dbPath: string): Promise<TursoDb> {
     if (this.closingPromise) {
       await this.closingPromise;
@@ -52,7 +54,7 @@ export class TursoConnectionManager {
         mkdirSync(dir, { recursive: true });
       }
 
-      const client: Client = createClient({ url: toFileUrl(dbPath) });
+      const client: Client = this.clientFactory({ url: toFileUrl(dbPath) });
       try {
         const db = new TursoDb(client);
         await db.execute("PRAGMA foreign_keys = ON");

--- a/src/services/turso/legacy-migrator.ts
+++ b/src/services/turso/legacy-migrator.ts
@@ -12,6 +12,7 @@ import { CONFIG } from "../../config.js";
 import { log } from "../logger.js";
 import { tursoConnectionManager } from "./connection-manager.js";
 import { tursoShardManager } from "./shard-manager.js";
+import { withSqliteFileLockRetry } from "./sqlite-handle-release.js";
 import { tursoVectorSearch } from "./vector-search.js";
 import { blobToFloat32Array } from "./vector-utils.js";
 import type { MemoryRecord } from "./types.js";
@@ -228,10 +229,10 @@ async function restoreFromBackup(dbPath: string): Promise<void> {
   await tursoConnectionManager.closeConnection(dbPath);
 
   if (existsSync(dbPath)) {
-    unlinkSync(dbPath);
+    await withSqliteFileLockRetry(() => unlinkSync(dbPath));
   }
 
-  renameSync(backup, dbPath);
+  await withSqliteFileLockRetry(() => renameSync(backup, dbPath));
 
   const sidecarPathFile = sidecarPath(dbPath);
   if (existsSync(sidecarPathFile)) {
@@ -421,7 +422,7 @@ async function migrateMemoryShard(dbPath: string): Promise<ShardMigrationSidecar
   const backup = backupPath(dbPath);
   await tursoConnectionManager.closeConnection(dbPath);
   if (existsSync(dbPath)) {
-    renameSync(dbPath, backup);
+    await withSqliteFileLockRetry(() => renameSync(dbPath, backup));
   }
 
   const freshDb = await tursoConnectionManager.getConnection(dbPath);

--- a/src/services/turso/legacy-migrator.ts
+++ b/src/services/turso/legacy-migrator.ts
@@ -328,7 +328,7 @@ async function migrateMemoryShard(dbPath: string): Promise<ShardMigrationSidecar
     return readSidecar(dbPath);
   }
 
-  const db = await tursoConnectionManager.getConnection(dbPath);
+  let db: TursoDb | null = await tursoConnectionManager.getConnection(dbPath);
   const hasTable = await hasMemoriesTable(db);
 
   if (!hasTable) {
@@ -420,6 +420,7 @@ async function migrateMemoryShard(dbPath: string): Promise<ShardMigrationSidecar
   });
 
   const backup = backupPath(dbPath);
+  db = null;
   await tursoConnectionManager.closeConnection(dbPath);
   if (existsSync(dbPath)) {
     await withSqliteFileLockRetry(() => renameSync(dbPath, backup));

--- a/src/services/turso/shard-manager.ts
+++ b/src/services/turso/shard-manager.ts
@@ -5,6 +5,7 @@ import { assertSafeScopeHash } from "../memory-scope.js";
 import { tursoConnectionManager } from "./connection-manager.js";
 import { log } from "../logger.js";
 import { assertNoTursoMigrationInProgress } from "./operation-lock.js";
+import { withSqliteFileLockRetry } from "./sqlite-handle-release.js";
 import type { ShardInfo } from "./types.js";
 import type { TursoDb } from "./turso-db.js";
 
@@ -504,7 +505,7 @@ export class TursoShardManager {
 
     try {
       if (existsSync(fullPath)) {
-        unlinkSync(fullPath);
+        await withSqliteFileLockRetry(() => unlinkSync(fullPath));
       }
     } catch (error) {
       log("Error deleting shard file", {
@@ -526,13 +527,13 @@ export class TursoShardManager {
     const archivePath = `${fullPath}.${reason}-${process.pid}-${Date.now()}.bak`;
 
     if (existsSync(fullPath)) {
-      renameSync(fullPath, archivePath);
+      await withSqliteFileLockRetry(() => renameSync(fullPath, archivePath));
     }
     try {
       await metadataDb.run(`DELETE FROM shards WHERE id = ?`, [shardId]);
     } catch (error) {
       if (existsSync(archivePath) && !existsSync(fullPath)) {
-        renameSync(archivePath, fullPath);
+        await withSqliteFileLockRetry(() => renameSync(archivePath, fullPath));
       }
       throw error;
     }

--- a/src/services/turso/sqlite-handle-release.ts
+++ b/src/services/turso/sqlite-handle-release.ts
@@ -20,6 +20,8 @@ function delay(ms: number): Promise<void> {
  * Upstream: https://github.com/tursodatabase/libsql-js/issues/228
  */
 export async function collectReleasedSqliteHandles(): Promise<void> {
+  if (process.platform !== "win32") return;
+
   const runtime = globalThis as RuntimeWithGarbageCollector;
   const bunGc = runtime.Bun?.gc;
   const globalGc = runtime.gc;

--- a/src/services/turso/sqlite-handle-release.ts
+++ b/src/services/turso/sqlite-handle-release.ts
@@ -1,0 +1,28 @@
+type RuntimeWithGarbageCollector = typeof globalThis & {
+  Bun?: {
+    gc?: (force?: boolean) => void;
+  };
+  gc?: () => void;
+};
+
+const GC_PASSES = 3;
+
+/**
+ * libsql 0.5.x leaves prepared-statement handles alive until garbage collection.
+ * Collect them before Windows file swaps/removals that require exclusive access.
+ *
+ * Upstream: https://github.com/tursodatabase/libsql-js/issues/228
+ */
+export async function collectReleasedSqliteHandles(): Promise<void> {
+  const runtime = globalThis as RuntimeWithGarbageCollector;
+  const bunGc = runtime.Bun?.gc;
+  const globalGc = runtime.gc;
+
+  if (!bunGc && !globalGc) return;
+
+  for (let pass = 0; pass < GC_PASSES; pass += 1) {
+    bunGc?.(true);
+    globalGc?.();
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  }
+}

--- a/src/services/turso/sqlite-handle-release.ts
+++ b/src/services/turso/sqlite-handle-release.ts
@@ -6,6 +6,12 @@ type RuntimeWithGarbageCollector = typeof globalThis & {
 };
 
 const GC_PASSES = 3;
+const FILE_LOCK_RETRY_DELAYS_MS = [10, 25, 50, 100, 200, 400, 800];
+const RETRYABLE_FILE_LOCK_CODES = new Set(["EBUSY", "EPERM", "EACCES"]);
+
+function delay(ms: number): Promise<void> {
+  return new Promise<void>((resolve) => setTimeout(resolve, ms));
+}
 
 /**
  * libsql 0.5.x leaves prepared-statement handles alive until garbage collection.
@@ -23,6 +29,32 @@ export async function collectReleasedSqliteHandles(): Promise<void> {
   for (let pass = 0; pass < GC_PASSES; pass += 1) {
     bunGc?.(true);
     globalGc?.();
-    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    await delay(0);
+  }
+}
+
+/**
+ * Retries Windows file mutations while stable libsql releases native handles.
+ * Non-lock errors and non-Windows platforms fail immediately.
+ */
+export async function withSqliteFileLockRetry<T>(operation: () => T | Promise<T>): Promise<T> {
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      return await operation();
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException)?.code;
+      const retryDelay = FILE_LOCK_RETRY_DELAYS_MS[attempt];
+      if (
+        process.platform !== "win32" ||
+        !code ||
+        !RETRYABLE_FILE_LOCK_CODES.has(code) ||
+        retryDelay === undefined
+      ) {
+        throw error;
+      }
+
+      await collectReleasedSqliteHandles();
+      await delay(retryDelay);
+    }
   }
 }

--- a/src/services/turso/sqlite-handle-release.ts
+++ b/src/services/turso/sqlite-handle-release.ts
@@ -6,7 +6,7 @@ type RuntimeWithGarbageCollector = typeof globalThis & {
 };
 
 const GC_PASSES = 3;
-const FILE_LOCK_RETRY_DELAYS_MS = [10, 25, 50, 100, 200, 400, 800];
+const FILE_LOCK_RETRY_DELAYS_MS = [25, 50, 100, 200, 400, 800, 1600, 3200];
 const RETRYABLE_FILE_LOCK_CODES = new Set(["EBUSY", "EPERM", "EACCES"]);
 
 function delay(ms: number): Promise<void> {

--- a/tests/project-scope.test.ts
+++ b/tests/project-scope.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
 import { basename, join } from "node:path";
 import { tmpdir } from "node:os";
 import { execSync } from "node:child_process";
-import { findMarkerProjectRoot, getProjectTagInfo } from "../src/services/tags.js";
+import { findMarkerProjectRoot, getGitCommonDir, getProjectTagInfo } from "../src/services/tags.js";
 
 const createdDirs: string[] = [];
 
@@ -44,9 +44,12 @@ describe("project scope identity", () => {
   it("uses one project tag across worktrees in the same repo", () => {
     const { repoDir, worktreeDir } = createRepoWithWorktree();
 
+    const mainCommonDir = getGitCommonDir(repoDir);
+    const worktreeCommonDir = getGitCommonDir(worktreeDir);
     const mainTag = getProjectTagInfo(repoDir);
     const worktreeTag = getProjectTagInfo(worktreeDir);
 
+    expect(mainCommonDir).toBe(worktreeCommonDir);
     expect(mainTag.tag).toBe(worktreeTag.tag);
     expect(mainTag.projectPath).toBe(worktreeTag.projectPath);
     expect(mainTag.projectName).toBe(basename(repoDir));

--- a/tests/turso-api-scope.test.ts
+++ b/tests/turso-api-scope.test.ts
@@ -1,15 +1,14 @@
 import { describe, expect, it, afterEach } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { cleanupTursoTestDirectory } from "./turso-test-utils.js";
 
 describe("api memory shard scope", () => {
   let baseDir: string;
 
   afterEach(async () => {
-    const { closeTursoAndInvalidateCaches } = await import("../src/services/turso/lifecycle.js");
-    await closeTursoAndInvalidateCaches();
-    if (baseDir) rmSync(baseDir, { recursive: true, force: true, maxRetries: 7, retryDelay: 50 });
+    await cleanupTursoTestDirectory(baseDir);
   });
 
   it("includes user-scope memories in stats, pin, and global search handlers", async () => {

--- a/tests/turso-api-scope.test.ts
+++ b/tests/turso-api-scope.test.ts
@@ -9,7 +9,7 @@ describe("api memory shard scope", () => {
   afterEach(async () => {
     const { closeTursoAndInvalidateCaches } = await import("../src/services/turso/lifecycle.js");
     await closeTursoAndInvalidateCaches();
-    if (baseDir) rmSync(baseDir, { recursive: true, force: true });
+    if (baseDir) rmSync(baseDir, { recursive: true, force: true, maxRetries: 7, retryDelay: 50 });
   });
 
   it("includes user-scope memories in stats, pin, and global search handlers", async () => {

--- a/tests/turso-auxiliary-db-upgrade.test.ts
+++ b/tests/turso-auxiliary-db-upgrade.test.ts
@@ -1,16 +1,15 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { cleanupTursoTestDirectory } from "./turso-test-utils.js";
 import { createClient } from "@libsql/client";
 
 describe("turso auxiliary database upgrades", () => {
   let baseDir: string;
 
   afterEach(async () => {
-    const { closeTursoAndInvalidateCaches } = await import("../src/services/turso/lifecycle.js");
-    await closeTursoAndInvalidateCaches();
-    if (baseDir) rmSync(baseDir, { recursive: true, force: true, maxRetries: 7, retryDelay: 50 });
+    await cleanupTursoTestDirectory(baseDir);
   });
 
   it("preserves legacy prompts while adding newer columns", async () => {

--- a/tests/turso-auxiliary-db-upgrade.test.ts
+++ b/tests/turso-auxiliary-db-upgrade.test.ts
@@ -10,7 +10,7 @@ describe("turso auxiliary database upgrades", () => {
   afterEach(async () => {
     const { closeTursoAndInvalidateCaches } = await import("../src/services/turso/lifecycle.js");
     await closeTursoAndInvalidateCaches();
-    if (baseDir) rmSync(baseDir, { recursive: true, force: true });
+    if (baseDir) rmSync(baseDir, { recursive: true, force: true, maxRetries: 7, retryDelay: 50 });
   });
 
   it("preserves legacy prompts while adding newer columns", async () => {

--- a/tests/turso-connection-lifecycle.test.ts
+++ b/tests/turso-connection-lifecycle.test.ts
@@ -9,7 +9,7 @@ describe("turso connection lifecycle", () => {
   afterEach(async () => {
     const { closeTursoAndInvalidateCaches } = await import("../src/services/turso/lifecycle.js");
     await closeTursoAndInvalidateCaches();
-    if (baseDir) rmSync(baseDir, { recursive: true, force: true });
+    if (baseDir) rmSync(baseDir, { recursive: true, force: true, maxRetries: 7, retryDelay: 50 });
   });
 
   it("reopens databases after closeTursoAndInvalidateCaches", async () => {

--- a/tests/turso-connection-lifecycle.test.ts
+++ b/tests/turso-connection-lifecycle.test.ts
@@ -1,15 +1,14 @@
 import { describe, expect, it, afterEach } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { cleanupTursoTestDirectory } from "./turso-test-utils.js";
 
 describe("turso connection lifecycle", () => {
   let baseDir: string;
 
   afterEach(async () => {
-    const { closeTursoAndInvalidateCaches } = await import("../src/services/turso/lifecycle.js");
-    await closeTursoAndInvalidateCaches();
-    if (baseDir) rmSync(baseDir, { recursive: true, force: true, maxRetries: 7, retryDelay: 50 });
+    await cleanupTursoTestDirectory(baseDir);
   });
 
   it("reopens databases after closeTursoAndInvalidateCaches", async () => {

--- a/tests/turso-connection-manager.test.ts
+++ b/tests/turso-connection-manager.test.ts
@@ -1,15 +1,14 @@
 import { describe, expect, it, afterEach } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { cleanupTursoTestDirectory } from "./turso-test-utils.js";
 
 describe("turso connection manager", () => {
   let baseDir: string;
 
   afterEach(async () => {
-    const { closeTursoAndInvalidateCaches } = await import("../src/services/turso/lifecycle.js");
-    await closeTursoAndInvalidateCaches();
-    if (baseDir) rmSync(baseDir, { recursive: true, force: true, maxRetries: 7, retryDelay: 50 });
+    await cleanupTursoTestDirectory(baseDir);
   });
 
   it("deduplicates concurrent getConnection calls for the same path", async () => {

--- a/tests/turso-connection-manager.test.ts
+++ b/tests/turso-connection-manager.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, afterEach } from "bun:test";
+import { describe, expect, it, afterEach, spyOn } from "bun:test";
 import { mkdtempSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -27,6 +27,64 @@ describe("turso connection manager", () => {
 
     expect(a).toBe(b);
     expect(b).toBe(c);
+  });
+
+  it("waits for an in-flight open before closing and serializes a reopen", async () => {
+    baseDir = mkdtempSync(join(tmpdir(), "turso-conn-close-race-"));
+    const { CONFIG } = await import("../src/config.js");
+    CONFIG.storagePath = baseDir;
+    const dbPath = join(baseDir, "close-race.db");
+
+    const { TursoConnectionManager } = await import("../src/services/turso/connection-manager.js");
+    const { TursoDb } = await import("../src/services/turso/turso-db.js");
+    const manager = new TursoConnectionManager();
+    const originalExecute = TursoDb.prototype.execute;
+    let releaseOpen!: () => void;
+    let markOpenStarted!: () => void;
+    const openGate = new Promise<void>((resolve) => {
+      releaseOpen = resolve;
+    });
+    const openStarted = new Promise<void>((resolve) => {
+      markOpenStarted = resolve;
+    });
+    let gateFirstOpen = true;
+    const executeSpy = spyOn(TursoDb.prototype, "execute").mockImplementation(
+      async function (sql, args) {
+        if (gateFirstOpen && sql === "PRAGMA foreign_keys = ON") {
+          gateFirstOpen = false;
+          markOpenStarted();
+          await openGate;
+        }
+        return originalExecute.call(this, sql, args);
+      }
+    );
+
+    try {
+      const opening = manager.getConnection(dbPath);
+      await openStarted;
+
+      let closeSettled = false;
+      const closing = manager.closeConnection(dbPath).then(() => {
+        closeSettled = true;
+      });
+      const reopening = manager.getConnection(dbPath);
+
+      await Promise.resolve();
+      expect(closeSettled).toBeFalse();
+
+      releaseOpen();
+      const opened = await opening;
+      await closing;
+      const reopened = await reopening;
+
+      expect(reopened).not.toBe(opened);
+      const row = await reopened.get(`PRAGMA foreign_keys`);
+      expect(Number((row as { foreign_keys?: number } | null)?.foreign_keys)).toBe(1);
+    } finally {
+      releaseOpen();
+      await manager.closeAll();
+      executeSpy.mockRestore();
+    }
   });
 
   it("enables foreign keys on new connections", async () => {

--- a/tests/turso-connection-manager.test.ts
+++ b/tests/turso-connection-manager.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it, afterEach, spyOn } from "bun:test";
+import { describe, expect, it, afterEach } from "bun:test";
+import type { Client } from "@libsql/client";
 import { mkdtempSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -35,10 +36,6 @@ describe("turso connection manager", () => {
     CONFIG.storagePath = baseDir;
     const dbPath = join(baseDir, "close-race.db");
 
-    const { TursoConnectionManager } = await import("../src/services/turso/connection-manager.js");
-    const { TursoDb } = await import("../src/services/turso/turso-db.js");
-    const manager = new TursoConnectionManager();
-    const originalExecute = TursoDb.prototype.execute;
     let releaseOpen!: () => void;
     let markOpenStarted!: () => void;
     const openGate = new Promise<void>((resolve) => {
@@ -47,17 +44,31 @@ describe("turso connection manager", () => {
     const openStarted = new Promise<void>((resolve) => {
       markOpenStarted = resolve;
     });
-    let gateFirstOpen = true;
-    const executeSpy = spyOn(TursoDb.prototype, "execute").mockImplementation(
-      async function (sql, args) {
-        if (gateFirstOpen && sql === "PRAGMA foreign_keys = ON") {
-          gateFirstOpen = false;
-          markOpenStarted();
-          await openGate;
-        }
-        return originalExecute.call(this, sql, args);
-      }
-    );
+    const clientStates: Array<{ closed: boolean }> = [];
+    const clientFactory = (): Client => {
+      const clientIndex = clientStates.length;
+      const state = { closed: false };
+      clientStates.push(state);
+      return {
+        async execute(statement: { sql: string }) {
+          if (clientIndex === 0 && statement.sql === "PRAGMA foreign_keys = ON") {
+            markOpenStarted();
+            await openGate;
+          }
+          return {
+            columns: statement.sql === "PRAGMA foreign_keys" ? ["foreign_keys"] : [],
+            columnTypes: [],
+            rows: statement.sql === "PRAGMA foreign_keys" ? [{ foreign_keys: 1 }] : [],
+            rowsAffected: 0,
+          };
+        },
+        close() {
+          state.closed = true;
+        },
+      } as unknown as Client;
+    };
+    const { TursoConnectionManager } = await import("../src/services/turso/connection-manager.js");
+    const manager = new TursoConnectionManager(clientFactory);
 
     try {
       const opening = manager.getConnection(dbPath);
@@ -78,12 +89,13 @@ describe("turso connection manager", () => {
       const reopened = await reopening;
 
       expect(reopened).not.toBe(opened);
+      expect(clientStates).toHaveLength(2);
+      expect(clientStates[0]?.closed).toBeTrue();
       const row = await reopened.get(`PRAGMA foreign_keys`);
       expect(Number((row as { foreign_keys?: number } | null)?.foreign_keys)).toBe(1);
     } finally {
       releaseOpen();
       await manager.closeAll();
-      executeSpy.mockRestore();
     }
   });
 

--- a/tests/turso-connection-manager.test.ts
+++ b/tests/turso-connection-manager.test.ts
@@ -9,7 +9,7 @@ describe("turso connection manager", () => {
   afterEach(async () => {
     const { closeTursoAndInvalidateCaches } = await import("../src/services/turso/lifecycle.js");
     await closeTursoAndInvalidateCaches();
-    if (baseDir) rmSync(baseDir, { recursive: true, force: true });
+    if (baseDir) rmSync(baseDir, { recursive: true, force: true, maxRetries: 7, retryDelay: 50 });
   });
 
   it("deduplicates concurrent getConnection calls for the same path", async () => {

--- a/tests/turso-dedup-extract.test.ts
+++ b/tests/turso-dedup-extract.test.ts
@@ -9,7 +9,7 @@ describe("turso dedup vector_extract", () => {
   afterEach(async () => {
     const { closeTursoAndInvalidateCaches } = await import("../src/services/turso/lifecycle.js");
     await closeTursoAndInvalidateCaches();
-    if (baseDir) rmSync(baseDir, { recursive: true, force: true });
+    if (baseDir) rmSync(baseDir, { recursive: true, force: true, maxRetries: 7, retryDelay: 50 });
   });
 
   it("detects near-duplicates using vector_extract JSON", async () => {

--- a/tests/turso-dedup-extract.test.ts
+++ b/tests/turso-dedup-extract.test.ts
@@ -1,15 +1,14 @@
 import { describe, expect, it, afterEach } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { cleanupTursoTestDirectory } from "./turso-test-utils.js";
 
 describe("turso dedup vector_extract", () => {
   let baseDir: string;
 
   afterEach(async () => {
-    const { closeTursoAndInvalidateCaches } = await import("../src/services/turso/lifecycle.js");
-    await closeTursoAndInvalidateCaches();
-    if (baseDir) rmSync(baseDir, { recursive: true, force: true, maxRetries: 7, retryDelay: 50 });
+    await cleanupTursoTestDirectory(baseDir);
   });
 
   it("detects near-duplicates using vector_extract JSON", async () => {

--- a/tests/turso-exact-fallback.test.ts
+++ b/tests/turso-exact-fallback.test.ts
@@ -1,15 +1,14 @@
 import { describe, expect, it, afterEach } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { cleanupTursoTestDirectory } from "./turso-test-utils.js";
 
 describe("turso exact scan fallback", () => {
   let baseDir: string;
 
   afterEach(async () => {
-    const { closeTursoAndInvalidateCaches } = await import("../src/services/turso/lifecycle.js");
-    await closeTursoAndInvalidateCaches();
-    if (baseDir) rmSync(baseDir, { recursive: true, force: true, maxRetries: 7, retryDelay: 50 });
+    await cleanupTursoTestDirectory(baseDir);
   });
 
   it("falls back to exact scan when vector_top_k index is missing", async () => {

--- a/tests/turso-exact-fallback.test.ts
+++ b/tests/turso-exact-fallback.test.ts
@@ -9,7 +9,7 @@ describe("turso exact scan fallback", () => {
   afterEach(async () => {
     const { closeTursoAndInvalidateCaches } = await import("../src/services/turso/lifecycle.js");
     await closeTursoAndInvalidateCaches();
-    if (baseDir) rmSync(baseDir, { recursive: true, force: true });
+    if (baseDir) rmSync(baseDir, { recursive: true, force: true, maxRetries: 7, retryDelay: 50 });
   });
 
   it("falls back to exact scan when vector_top_k index is missing", async () => {

--- a/tests/turso-legacy-migrator.test.ts
+++ b/tests/turso-legacy-migrator.test.ts
@@ -10,7 +10,7 @@ describe("turso legacy migrator", () => {
   afterEach(async () => {
     const { closeTursoAndInvalidateCaches } = await import("../src/services/turso/lifecycle.js");
     await closeTursoAndInvalidateCaches();
-    if (baseDir) rmSync(baseDir, { recursive: true, force: true });
+    if (baseDir) rmSync(baseDir, { recursive: true, force: true, maxRetries: 7, retryDelay: 50 });
   });
 
   async function createLegacyShard(

--- a/tests/turso-legacy-migrator.test.ts
+++ b/tests/turso-legacy-migrator.test.ts
@@ -2,15 +2,14 @@ import { describe, expect, it, afterEach } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { cleanupTursoTestDirectory } from "./turso-test-utils.js";
 import { createClient } from "@libsql/client";
 
 describe("turso legacy migrator", () => {
   let baseDir: string;
 
   afterEach(async () => {
-    const { closeTursoAndInvalidateCaches } = await import("../src/services/turso/lifecycle.js");
-    await closeTursoAndInvalidateCaches();
-    if (baseDir) rmSync(baseDir, { recursive: true, force: true, maxRetries: 7, retryDelay: 50 });
+    await cleanupTursoTestDirectory(baseDir);
   });
 
   async function createLegacyShard(

--- a/tests/turso-migrate-dims-preflight.test.ts
+++ b/tests/turso-migrate-dims-preflight.test.ts
@@ -1,16 +1,15 @@
 import { describe, expect, it, afterEach } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { cleanupTursoTestDirectory } from "./turso-test-utils.js";
 import { createClient } from "@libsql/client";
 
 describe("turso legacy migrator dimension preflight", () => {
   let baseDir: string;
 
   afterEach(async () => {
-    const { closeTursoAndInvalidateCaches } = await import("../src/services/turso/lifecycle.js");
-    await closeTursoAndInvalidateCaches();
-    if (baseDir) rmSync(baseDir, { recursive: true, force: true, maxRetries: 7, retryDelay: 50 });
+    await cleanupTursoTestDirectory(baseDir);
   });
 
   it("preserves legacy dimensions so startup can expose the re-embed migration", async () => {

--- a/tests/turso-migrate-dims-preflight.test.ts
+++ b/tests/turso-migrate-dims-preflight.test.ts
@@ -10,7 +10,7 @@ describe("turso legacy migrator dimension preflight", () => {
   afterEach(async () => {
     const { closeTursoAndInvalidateCaches } = await import("../src/services/turso/lifecycle.js");
     await closeTursoAndInvalidateCaches();
-    if (baseDir) rmSync(baseDir, { recursive: true, force: true });
+    if (baseDir) rmSync(baseDir, { recursive: true, force: true, maxRetries: 7, retryDelay: 50 });
   });
 
   it("preserves legacy dimensions so startup can expose the re-embed migration", async () => {

--- a/tests/turso-ready-gate.test.ts
+++ b/tests/turso-ready-gate.test.ts
@@ -9,7 +9,7 @@ describe("turso ready gate", () => {
   afterEach(async () => {
     const { closeTursoAndInvalidateCaches } = await import("../src/services/turso/lifecycle.js");
     await closeTursoAndInvalidateCaches();
-    if (baseDir) rmSync(baseDir, { recursive: true, force: true });
+    if (baseDir) rmSync(baseDir, { recursive: true, force: true, maxRetries: 7, retryDelay: 50 });
   });
 
   it("runs legacy migration once and initializes metadata", async () => {

--- a/tests/turso-ready-gate.test.ts
+++ b/tests/turso-ready-gate.test.ts
@@ -1,15 +1,14 @@
 import { describe, expect, it, afterEach } from "bun:test";
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { cleanupTursoTestDirectory } from "./turso-test-utils.js";
 
 describe("turso ready gate", () => {
   let baseDir: string;
 
   afterEach(async () => {
-    const { closeTursoAndInvalidateCaches } = await import("../src/services/turso/lifecycle.js");
-    await closeTursoAndInvalidateCaches();
-    if (baseDir) rmSync(baseDir, { recursive: true, force: true, maxRetries: 7, retryDelay: 50 });
+    await cleanupTursoTestDirectory(baseDir);
   });
 
   it("runs legacy migration once and initializes metadata", async () => {

--- a/tests/turso-reembed-migration.test.ts
+++ b/tests/turso-reembed-migration.test.ts
@@ -22,7 +22,7 @@ describe("turso re-embed migration safety", () => {
     restoreEmbedding = undefined;
     const { closeTursoAndInvalidateCaches } = await import("../src/services/turso/lifecycle.js");
     await closeTursoAndInvalidateCaches();
-    if (baseDir) rmSync(baseDir, { recursive: true, force: true });
+    if (baseDir) rmSync(baseDir, { recursive: true, force: true, maxRetries: 7, retryDelay: 50 });
   });
 
   async function createSourceShard() {

--- a/tests/turso-reembed-migration.test.ts
+++ b/tests/turso-reembed-migration.test.ts
@@ -5,11 +5,11 @@ import {
   mkdtempSync,
   readdirSync,
   renameSync,
-  rmSync,
   writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { cleanupTursoTestDirectory } from "./turso-test-utils.js";
 
 const SCOPE_HASH = "0123456789abcdef";
 
@@ -20,9 +20,7 @@ describe("turso re-embed migration safety", () => {
   afterEach(async () => {
     restoreEmbedding?.();
     restoreEmbedding = undefined;
-    const { closeTursoAndInvalidateCaches } = await import("../src/services/turso/lifecycle.js");
-    await closeTursoAndInvalidateCaches();
-    if (baseDir) rmSync(baseDir, { recursive: true, force: true, maxRetries: 7, retryDelay: 50 });
+    await cleanupTursoTestDirectory(baseDir);
   });
 
   async function createSourceShard() {

--- a/tests/turso-shard-recreate.test.ts
+++ b/tests/turso-shard-recreate.test.ts
@@ -11,7 +11,7 @@ describe("turso invalid shard protection", () => {
   afterEach(async () => {
     const { closeTursoAndInvalidateCaches } = await import("../src/services/turso/lifecycle.js");
     await closeTursoAndInvalidateCaches();
-    if (baseDir) rmSync(baseDir, { recursive: true, force: true });
+    if (baseDir) rmSync(baseDir, { recursive: true, force: true, maxRetries: 7, retryDelay: 50 });
   });
 
   it("rejects writes on dimension mismatch without moving or emptying the shard", async () => {

--- a/tests/turso-shard-recreate.test.ts
+++ b/tests/turso-shard-recreate.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { cleanupTursoTestDirectory } from "./turso-test-utils.js";
 
 const TEST_SCOPE_HASH = "a1b2c3d4e5f67890";
 
@@ -9,9 +10,7 @@ describe("turso invalid shard protection", () => {
   let baseDir: string;
 
   afterEach(async () => {
-    const { closeTursoAndInvalidateCaches } = await import("../src/services/turso/lifecycle.js");
-    await closeTursoAndInvalidateCaches();
-    if (baseDir) rmSync(baseDir, { recursive: true, force: true, maxRetries: 7, retryDelay: 50 });
+    await cleanupTursoTestDirectory(baseDir);
   });
 
   it("rejects writes on dimension mismatch without moving or emptying the shard", async () => {

--- a/tests/turso-shard-rotation.test.ts
+++ b/tests/turso-shard-rotation.test.ts
@@ -9,7 +9,7 @@ describe("turso shard rotation", () => {
   afterEach(async () => {
     const { closeTursoAndInvalidateCaches } = await import("../src/services/turso/lifecycle.js");
     await closeTursoAndInvalidateCaches();
-    if (baseDir) rmSync(baseDir, { recursive: true, force: true });
+    if (baseDir) rmSync(baseDir, { recursive: true, force: true, maxRetries: 7, retryDelay: 50 });
   });
 
   it("marks a full shard read-only and creates the next shard", async () => {

--- a/tests/turso-shard-rotation.test.ts
+++ b/tests/turso-shard-rotation.test.ts
@@ -1,15 +1,14 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { cleanupTursoTestDirectory } from "./turso-test-utils.js";
 
 describe("turso shard rotation", () => {
   let baseDir: string;
 
   afterEach(async () => {
-    const { closeTursoAndInvalidateCaches } = await import("../src/services/turso/lifecycle.js");
-    await closeTursoAndInvalidateCaches();
-    if (baseDir) rmSync(baseDir, { recursive: true, force: true, maxRetries: 7, retryDelay: 50 });
+    await cleanupTursoTestDirectory(baseDir);
   });
 
   it("marks a full shard read-only and creates the next shard", async () => {

--- a/tests/turso-test-utils.ts
+++ b/tests/turso-test-utils.ts
@@ -1,0 +1,13 @@
+import { rmSync } from "node:fs";
+
+export async function cleanupTursoTestDirectory(baseDir?: string): Promise<void> {
+  const [{ closeTursoAndInvalidateCaches }, { withSqliteFileLockRetry }] = await Promise.all([
+    import("../src/services/turso/lifecycle.js"),
+    import("../src/services/turso/sqlite-handle-release.js"),
+  ]);
+
+  await closeTursoAndInvalidateCaches();
+  if (baseDir) {
+    await withSqliteFileLockRetry(() => rmSync(baseDir, { recursive: true, force: true }));
+  }
+}

--- a/tests/turso-vector-search.test.ts
+++ b/tests/turso-vector-search.test.ts
@@ -64,6 +64,6 @@ describe("turso vector search", () => {
     await tursoConnectionManager.closeAll();
     const { closeTursoAndInvalidateCaches } = await import("../src/services/turso/lifecycle.js");
     await closeTursoAndInvalidateCaches();
-    rmSync(baseDir, { recursive: true, force: true });
+    rmSync(baseDir, { recursive: true, force: true, maxRetries: 7, retryDelay: 50 });
   });
 });

--- a/tests/turso-vector-search.test.ts
+++ b/tests/turso-vector-search.test.ts
@@ -1,11 +1,18 @@
-import { describe, expect, it } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtempSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { cleanupTursoTestDirectory } from "./turso-test-utils.js";
 
 describe("turso vector search", () => {
+  let baseDir: string;
+
+  afterEach(async () => {
+    await cleanupTursoTestDirectory(baseDir);
+  });
+
   it("inserts and searches memories with native vector index", async () => {
-    const baseDir = mkdtempSync(join(tmpdir(), "turso-vector-test-"));
+    baseDir = mkdtempSync(join(tmpdir(), "turso-vector-test-"));
 
     const { CONFIG } = await import("../src/config.js");
     CONFIG.storagePath = baseDir;
@@ -60,10 +67,5 @@ describe("turso vector search", () => {
       "turso"
     );
     expect(limitedResults).toHaveLength(1);
-
-    await tursoConnectionManager.closeAll();
-    const { closeTursoAndInvalidateCaches } = await import("../src/services/turso/lifecycle.js");
-    await closeTursoAndInvalidateCaches();
-    rmSync(baseDir, { recursive: true, force: true, maxRetries: 7, retryDelay: 50 });
   });
 });


### PR DESCRIPTION
## Root causes

1. `Platform Package Smoke` ran `bun test` before `bun run build`; clean runners had no `dist/` for contract/bundle tests.
2. Stable `libsql` 0.5.x can retain prepared-statement/native file handles after `Database.close()` on Windows, causing `EBUSY`/`EPERM` during migration swaps and test cleanup (upstream: https://github.com/tursodatabase/libsql-js/issues/228).
3. `closeConnection()` did not wait for an in-flight open in the manager's `pending` map, allowing the open to finish after “close” and re-lock the database during a swap.
4. `macos-13` was retired by GitHub Actions in December 2025 and no longer starts jobs.
5. npm ignores `overrides` declared by an installed dependency. The packed-package smoke therefore installed `onnxruntime-node@1.24.3`, which has no Darwin x64 binary, instead of the package's pinned `1.22.0` runtime (upstream: https://github.com/microsoft/onnxruntime/issues/27961).
6. Windows Git worktree identity could differ between long and 8.3 path spellings.

## Fix

- Build package artifacts before running the test suite.
- Restrict forced handle collection to Windows and add bounded retries for lock-like file mutation failures.
- Apply retries to migration swaps, archive/delete paths, rollback paths, and staged-file cleanup without weakening transaction/error semantics.
- Release the local legacy DB reference before close/GC.
- Serialize per-path close/open operations, wait for pending opens before closing, and cover the race with a deterministic fake-client test that does not add native teardown state.
- Centralize strict Turso test cleanup around the same close/retry behavior.
- Run the libSQL vector smoke in a child process so the parent removes test files only after native handles are released.
- Replace retired `macos-13` with `macos-15-intel` while retaining Apple Silicon coverage on `macos-15`.
- Mirror the package's optional ONNX runtime override into the temporary npm smoke root; native loading remains a hard failure.
- Canonicalize Windows Git paths with `realpathSync.native()`.

## Verification

Final head: `71779bd5c0d40f36eacb116e8496ea9f644f6b43`

Local:

- `bun install --frozen-lockfile`
- `bun run typecheck`
- `bun run build`
- `bun test` — **269 pass, 0 fail, 591 assertions**
- libSQL vector smoke — **5/5 pass, 0 leftover files**
- Turso-focused suite — **3 consecutive passes (30/30 each)**
- `git diff --check`

GitHub Actions final run: https://github.com/tickernelz/opencode-mem/actions/runs/30358481646

- `ubuntu-latest / package smoke` — success
- `windows-latest / package smoke` — success
- `macos-15 / package smoke` — success
- `macos-15-intel / package smoke` — success
- GitGuardian Security Checks — success

Runtime and CI fixes were published in [v2.21.1](https://github.com/tickernelz/opencode-mem/releases/tag/v2.21.1).
