### PR TITLE
chore: release v2.21.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-mem",
-  "version": "2.21.0",
+  "version": "2.21.1",
   "description": "OpenCode plugin that gives coding agents persistent memory using local Turso/libSQL vector search",
   "type": "module",
   "main": "dist/plugin.js",


### PR DESCRIPTION
## Release

Patch release for the cross-platform package-smoke and Turso/libSQL lifecycle fixes merged in #200.

## Included fixes

- build artifacts before clean-runner tests/package smoke
- serialize Turso close/open races and release Windows libSQL handles before file mutations
- bounded Windows lock retries for migration/file cleanup paths
- stable Windows Git worktree path identity
- isolated libSQL vector smoke cleanup
- replace retired `macos-13` with `macos-15-intel`
- preserve the package's optional `onnxruntime-node` override in packed-consumer smoke tests

## Verification

- `bun install --frozen-lockfile`
- `bun run typecheck`
- `bun run build`
- `bun test` — **269 pass, 0 fail, 591 assertions**
- `npm pack --dry-run --ignore-scripts --json` — version `2.21.1`, 200 files, manifest and `dist/plugin.js` present
- #200 final matrix: Ubuntu, Windows, macOS ARM, and macOS Intel all green

Version-only release commit; tag `v2.21.1` will be created from the merged release commit after this PR is green.
