### PR TITLE
chore: release v2.22.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-mem",
-  "version": "2.21.1",
+  "version": "2.22.0",
   "description": "OpenCode plugin that gives coding agents persistent memory using local Turso/libSQL vector search",
   "type": "module",
   "main": "dist/plugin.js",


### PR DESCRIPTION
## Summary

- bump `opencode-mem` from `2.21.1` to `2.22.0`
- release the React 19 Memory Explorer replacement (#201)
- release opt-in Nomic embedding task prefixes (#199)
- release Intel Mac nested-install ONNX runtime hardening (#198)
- release structured-output session tool isolation (#197)

## Verification

- `bun install --frozen-lockfile`
- `cd web && bun install --frozen-lockfile`
- `bun run typecheck`
- `bun run build`
- `bun test` — **287 passed / 0 failed / 631 assertions**
- `bun run format:check`
- `npm pack --dry-run --ignore-scripts --json` — 213 files; package version `2.22.0`; `dist/plugin.js` and `dist/web/index.html` present
- tarball install smoke — native dependencies, libSQL vector operations, and package entrypoint all passed

## Dependency audit note

`npm audit --omit=dev` reports the same five high-severity transitive findings as published `v2.21.1` (`@huggingface/transformers`, `adm-zip`, `onnxruntime-node`, `sharp`, and the root package rollup), with no new finding introduced by this release.