### PR TITLE
ci(release): install web dependencies before build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,12 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
 
-      - run: bun install
+      - name: Install source dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Install web dependencies
+        working-directory: web
+        run: bun install --frozen-lockfile
 
       - run: bun run typecheck
 


### PR DESCRIPTION
## Problem

The `v2.22.0` release run failed during `bun run build` because the release workflow installed only root dependencies. Since #201, the root build invokes the `web` TypeScript/Vite build, which requires `web/node_modules`.

Failed run: https://github.com/tickernelz/opencode-mem/actions/runs/30507159676

## Fix

- install root dependencies with `bun install --frozen-lockfile`
- install `web` dependencies from `web/bun.lock` before typecheck/build

## Verification

Reproduced the exact release install/typecheck/build sequence in a clean detached worktree with neither root nor web `node_modules` present:

- root frozen install: pass
- web frozen install: pass
- `bun run typecheck`: pass
- `bun run build`: pass
- `dist/plugin.js`: present
- `dist/web/index.html`: present
