### PR TITLE
fix: test permission bits instead of comparing the secret file mode numerically

### DIFF
--- a/src/services/secret-resolver.ts
+++ b/src/services/secret-resolver.ts
@@ -12,6 +12,10 @@ function expandPath(path: string): string {
   return path;
 }
 
+// Any group or other bit set means someone besides the owner can reach the
+// secret. Owner bits are deliberately excluded: 0600 and 0400 are both fine.
+const GROUP_AND_OTHER_BITS = 0o077;
+
 function checkFilePermissions(filePath: string): void {
   if (platform() === "win32") {
     return;
@@ -21,9 +25,17 @@ function checkFilePermissions(filePath: string): void {
     const stats = statSync(filePath);
     const mode = stats.mode & 0o777;
 
-    if (mode > 0o600) {
+    // Test the bits, not the numeric value. `mode > 0o600` compared a bitmask as
+    // an integer, so it missed every mode that grants group/other access while
+    // sorting numerically lower -- 0404 (world-readable) and 0006
+    // (world-writable) passed silently, while 0640, strictly less permissive
+    // than 0644, warned. The comparison and the property being checked were
+    // simply unrelated.
+    const exposedBits = mode & GROUP_AND_OTHER_BITS;
+
+    if (exposedBits !== 0) {
       console.warn(
-        `Warning: Secret file ${filePath} has permissive permissions (${mode.toString(8)}). Recommend chmod 600.`
+        `Warning: Secret file ${filePath} has permissive permissions (${mode.toString(8).padStart(3, "0")}) granting group/other access. Recommend chmod 600.`
       );
     }
   } catch (error) {

--- a/tests/secret-resolver-permissions.test.ts
+++ b/tests/secret-resolver-permissions.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, it, spyOn } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import { resolveSecretValue } from "../src/services/secret-resolver.js";
+
+/**
+ * `checkFilePermissions` warns when a `file://` secret is readable by anyone
+ * besides its owner. It used to test `mode > 0o600`, comparing a bitmask as an
+ * integer -- so it missed every mode that grants group/other access while
+ * sorting numerically lower, and warned on modes that were strictly safer than
+ * ones it let through.
+ */
+describe("secret file permission warnings", () => {
+  const SECRET = "sk-super-secret-value";
+  let spies: ReturnType<typeof spyOn>[] = [];
+  let warnings: string[] = [];
+
+  function arrange(mode: number, platformName = "linux") {
+    warnings = [];
+    spies = [
+      spyOn(os, "platform").mockReturnValue(platformName as ReturnType<typeof os.platform>),
+      spyOn(fs, "existsSync").mockReturnValue(true),
+      spyOn(fs, "readFileSync").mockReturnValue(`${SECRET}\n` as never),
+      // Only the permission bits are consulted; the file-type bits above 0o777
+      // are included so the mask in the source is what strips them.
+      spyOn(fs, "statSync").mockReturnValue({ mode: 0o100000 | mode } as never),
+      spyOn(console, "warn").mockImplementation((...args: unknown[]) => {
+        warnings.push(args.map(String).join(" "));
+      }),
+    ];
+  }
+
+  afterEach(() => {
+    for (const spy of spies) spy.mockRestore();
+    spies = [];
+  });
+
+  const warned = () => warnings.some((line) => line.includes("permissive permissions"));
+
+  // Owner-only modes: no exposure, so no warning.
+  const SAFE_MODES = [0o600, 0o400, 0o200, 0o700, 0o000];
+
+  // Every one of these grants read, write or execute to group or other.
+  const EXPOSED_MODES = [
+    0o644, // rw-r--r--  world-readable
+    0o640, // rw-r-----  group-readable
+    0o604, // rw----r--  world-readable
+    0o606, // rw----rw-  world-writable
+    0o404, // r-----r--  world-readable, and NUMERICALLY BELOW 0o600
+    0o060, // ---rw----  group-writable, numerically below 0o600
+    0o006, // ------rw-  world-writable, numerically below 0o600
+    0o007, // ------rwx  world-executable, numerically below 0o600
+    0o077, // ---rwxrwx  group+other everything, numerically below 0o600
+    0o777, // rwxrwxrwx
+  ];
+
+  it.each(SAFE_MODES)("does not warn for owner-only mode %s", (mode) => {
+    arrange(mode);
+    expect(resolveSecretValue("file:///tmp/secret")).toBe(SECRET);
+    expect(warned()).toBe(false);
+  });
+
+  it.each(EXPOSED_MODES)("warns for group/other-accessible mode %s", (mode) => {
+    arrange(mode);
+    expect(resolveSecretValue("file:///tmp/secret")).toBe(SECRET);
+    expect(warned()).toBe(true);
+  });
+
+  it("warns for a world-readable file that sorts below the old threshold", () => {
+    // The headline case. 0o404 is world-readable, yet `0o404 > 0o600` is false, so
+    // it passed silently -- while 0o640, which exposes strictly less, warned.
+    arrange(0o404);
+    resolveSecretValue("file:///tmp/secret");
+    const exposed = warned();
+
+    arrange(0o640);
+    resolveSecretValue("file:///tmp/secret");
+    const lessExposed = warned();
+
+    expect(exposed).toBe(true);
+    expect(lessExposed).toBe(true);
+  });
+
+  it("reports the mode in octal, zero-padded", () => {
+    // A mode like 0o006 must not render as "6"; the message is the only signal
+    // the user gets, so it has to name the mode it is complaining about.
+    arrange(0o006);
+    resolveSecretValue("file:///tmp/secret");
+    expect(warnings.join("\n")).toContain("(006)");
+  });
+
+  it("still skips the check entirely on win32", () => {
+    // POSIX mode bits are not meaningful there, and the early return is
+    // deliberate -- unchanged by this fix.
+    arrange(0o777, "win32");
+    expect(resolveSecretValue("file:///tmp/secret")).toBe(SECRET);
+    expect(warned()).toBe(false);
+  });
+
+  it("returns the secret regardless of the warning", () => {
+    // The check advises; it must never block a resolution that would otherwise
+    // succeed, or a permission nit would take the plugin down.
+    arrange(0o777);
+    expect(resolveSecretValue("file:///tmp/secret")).toBe(SECRET);
+    expect(warned()).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes #205

### What was wrong

`checkFilePermissions` decided whether a `file://` secret is exposed with `mode > 0o600` — comparing a **bitmask as an integer**. Permission bits are three independent 3-bit fields, and their numeric ordering does not track how exposed a file is, because a change in the owner field outweighs any change in the group/other fields.

| mode | symbolic | meaning | before | after |
| --- | --- | --- | --- | --- |
| `0600` | `rw-------` | owner only | no warn | no warn |
| `0400` | `r--------` | owner read only | no warn | no warn |
| `0700` | `rwx------` | owner only | **warn** | no warn |
| `0644` | `rw-r--r--` | world-readable | warn | warn |
| `0640` | `rw-r-----` | group-readable | warn | warn |
| `0404` | `r-----r--` | **world-readable** | **no warn** | warn |
| `0060` | `---rw----` | group-writable | **no warn** | warn |
| `0006` | `------rw-` | **world-writable** | **no warn** | warn |
| `0007` | `------rwx` | **world-rwx** | **no warn** | warn |
| `0077` | `---rwxrwx` | group+other everything | **no warn** | warn |
| `0777` | `rwxrwxrwx` | everything | warn | warn |

Six of eleven were classified wrongly. The sharpest pair: **`0404` is world-readable and was silent, while `0640` exposes strictly less and warned.**

`resolveSecretValue` is the accessor for `memoryApiKey`, `embeddingApiKey`, `webServerAuthPassword` and `webServerApiToken` (`src/config.ts:563`, `:586`, `:620`, `:623`). This warning is the only feedback a user gets that a credential file is reachable by other accounts on the machine.

### What changed

```ts
const GROUP_AND_OTHER_BITS = 0o077;
const exposedBits = mode & GROUP_AND_OTHER_BITS;
if (exposedBits !== 0) { /* warn */ }
```

Owner bits stay excluded, so `0600`, `0400` and `0700` are all accepted — the question is whether anyone *else* can reach the secret, which also removes the spurious `0700` warning.

The message now zero-pads the mode. `0o006` previously rendered as `(6)`, and since the message is the entire signal the user receives it should name the mode unambiguously. It also says *why* — "granting group/other access".

**Deliberately unchanged:** the `win32` early return (POSIX mode bits are not meaningful there), and the fact that the check only advises. It must never block a resolution that would otherwise succeed, or a permission nit would take the plugin down — that has a test of its own.

### Scope note

This is advisory output, not an access control. The file is already readable by whoever the mode allows, and this change does not alter who can read it. What it fixes is a check that reported "fine" for the exact configuration it exists to flag.

### Verification

- `bun test tests/secret-resolver-permissions.test.ts`: **19 pass / 0 fail**.
- With `src/services/secret-resolver.ts` reverted to `main` and the new tests kept: **8 fail / 11 pass**. One of those failures is the false *positive* (`0700` warning needlessly), so the tests pin both directions.
- Full `bun test`: **297 pass / 9 fail** vs baseline **278 / 9** — exactly +19, **no new failures**. (Those 9 are pre-existing here: `plugin-loader-contract` and `plugin-bundle-boundary` require a built `dist/`.)
- `tsc --noEmit`: clean. `prettier --check`: clean. The husky pre-commit hook ran both and passed.

### Tests added

`tests/secret-resolver-permissions.test.ts` — 19 cases, using the `spyOn(fs, …)` style already used in `tests/config-resolution.test.ts`:

- `it.each` over 5 owner-only modes (`0600`, `0400`, `0200`, `0700`, `0000`) asserting **no** warning — this is what catches the `0700` false positive
- `it.each` over 10 group/other-accessible modes asserting a warning, including the five that sort numerically below `0o600`
- the `0404` vs `0640` pair asserted together, since the bug is most legible as a contradiction between them
- the mode is rendered zero-padded (`(006)`, not `(6)`)
- `win32` still skips the check entirely
- the secret is still returned when the warning fires — the check advises, it does not block

`statSync` is mocked with the file-type bits set (`0o100000 | mode`) so that the `& 0o777` mask in the source is what strips them, rather than the test quietly handing over pre-masked input.
