### PR TITLE
chore: release v2.22.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-mem",
-  "version": "2.22.0",
+  "version": "2.22.1",
   "description": "OpenCode plugin that gives coding agents persistent memory using local Turso/libSQL vector search",
   "type": "module",
   "main": "dist/plugin.js",


### PR DESCRIPTION
## Summary

- bump `opencode-mem` from `2.22.0` to `2.22.1`

## Verification

- `bun install --frozen-lockfile`
- `cd web && bun install --frozen-lockfile`
- `bun run typecheck`
- `bun run build`
- `bun test` — 323 passed, 0 failed; Bun 1.3.14 crashed during teardown on macOS after completing the suite
- `bun run format:check`