### PR TITLE
chore: release v2.22.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-mem",
-  "version": "2.22.1",
+  "version": "2.22.2",
   "description": "OpenCode plugin that gives coding agents persistent memory using local Turso/libSQL vector search",
   "type": "module",
   "main": "dist/plugin.js",


### PR DESCRIPTION
## Summary

- bump `opencode-mem` from `2.22.1` to `2.22.2`
- release the OpenCode Bun compile-host resolver fix from #223

## Verification

- `bun install --frozen-lockfile`
- `cd web && bun install --frozen-lockfile`
- `bun run typecheck`
- `bun run build`
- `bun test` — 330 passed, 0 failed
- `bun run format:check`

Made with [Cursor](https://cursor.com)