### PR TITLE
chore: release v2.22.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-mem",
-  "version": "2.22.2",
+  "version": "2.22.3",
   "description": "OpenCode plugin that gives coding agents persistent memory using local Turso/libSQL vector search",
   "type": "module",
   "main": "dist/plugin.js",


### PR DESCRIPTION
## Summary
- bump `opencode-mem` from `2.22.2` to `2.22.3`
- release the Intel macOS ONNX Runtime shutdown fix from #227

## Verification
- all checks passed on #227, including the `macos-15-intel` compiled-host inference and natural-exit regression
- release PR typecheck runs via the commit hook

Made with [Cursor](https://cursor.com)