### PR TITLE
chore: release v2.23.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-mem",
-  "version": "2.22.3",
+  "version": "2.23.0",
   "description": "OpenCode plugin that gives coding agents persistent memory using local Turso/libSQL vector search",
   "type": "module",
   "main": "dist/plugin.js",


### PR DESCRIPTION
## Summary
- bump `opencode-mem` from `2.22.3` to `2.23.0`
- release the MiniMax provider support from #222

## Verification
- all Platform Package Smoke checks passed on #222
- release PR typecheck runs via the commit hook


Made with [Cursor](https://cursor.com)