### PR TITLE
chore: release v2.24.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-mem",
-  "version": "2.23.0",
+  "version": "2.24.0",
   "description": "OpenCode plugin that gives coding agents persistent memory using local Turso/libSQL vector search",
   "type": "module",
   "main": "dist/plugin.js",

--- a/src/services/shard-path-migration-service.ts
+++ b/src/services/shard-path-migration-service.ts
@@ -18,7 +18,6 @@ import { tursoVectorSearch } from "./turso/vector-search.js";
 import { withSqliteFileLockRetry } from "./turso/sqlite-handle-release.js";
 import { log } from "./logger.js";
 import {
-  normalizeProjectPath,
   shardInventoryService,
   type ResolveMigrationSourceOptions,
   type ResolvedMigrationSource,
@@ -362,10 +361,7 @@ export class ShardPathMigrationService {
       // recoverable memory migration.
       if (source.group.projectPath && target.projectPath) {
         try {
-          await userPromptManager.updateProjectPath(
-            normalizeProjectPath(source.group.projectPath),
-            normalizeProjectPath(target.projectPath)
-          );
+          await userPromptManager.updateProjectPath(source.group.projectPath, target.projectPath);
         } catch (error) {
           log("Path migration prompt metadata update failed", { error: String(error) });
         }

--- a/src/services/user-prompt/user-prompt-manager.ts
+++ b/src/services/user-prompt/user-prompt-manager.ts
@@ -373,10 +373,13 @@ export class UserPromptManager {
       return 0;
     }
     const db = await this.ready();
-    return db.run(`UPDATE user_prompts SET project_path = ? WHERE project_path = ?`, [
-      newProjectPath,
-      oldProjectPath,
-    ]);
+    const normalizedOldPath = oldProjectPath.replace(/\\/g, "/");
+    return db.run(
+      `UPDATE user_prompts
+       SET project_path = ?
+       WHERE REPLACE(project_path, '\\', '/') = ?`,
+      [newProjectPath, normalizedOldPath]
+    );
   }
 
   private rowToPrompt(row: Record<string, unknown>): UserPrompt {

--- a/tests/shard-path-migrate.test.ts
+++ b/tests/shard-path-migrate.test.ts
@@ -426,4 +426,26 @@ describe("shard path migration", () => {
     expect(await tursoShardManager.getAllShards("project", oldHash)).toHaveLength(1);
     expect(await tursoShardManager.getAllShards("project", newHash)).toHaveLength(0);
   });
+
+  it("updates stored Windows prompt paths using separator-independent matching", async () => {
+    await createProjects();
+    const { userPromptManager } =
+      await import("../src/services/user-prompt/user-prompt-manager.js");
+    const promptId = await userPromptManager.savePrompt(
+      "windows-session",
+      "windows-message",
+      "C:\\workspace\\old-project",
+      "Windows path prompt"
+    );
+
+    const updated = await userPromptManager.updateProjectPath(
+      "C:/workspace/old-project",
+      "C:\\workspace\\new-project"
+    );
+
+    expect(updated).toBe(1);
+    expect((await userPromptManager.getPromptById(promptId))?.projectPath).toBe(
+      "C:\\workspace\\new-project"
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- release project memory portability commands: `list-shards`, `migrate`, `export`, and `import`
- add crash-safe shard reassociation, portable backups, and re-embedding on import
- bump package version to `2.24.0`

Closes #234

## Test plan
- [x] `bun run typecheck`
- [x] `bun test` (364 passed)
- [x] live add → migrate → export → import smoke test against the local libSQL store and real embedding model


Made with [Cursor](https://cursor.com)