### PR TITLE
chore: release v2.24.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-mem",
-  "version": "2.24.0",
+  "version": "2.24.1",
   "description": "OpenCode plugin that gives coding agents persistent memory using local Turso/libSQL vector search",
   "type": "module",
   "main": "dist/plugin.js",


### PR DESCRIPTION
## Summary
- bump `opencode-mem` from `2.24.0` to `2.24.1`
- release the profile, auto-capture, and compaction fixes from #239

Resolves [#231](https://github.com/tickernelz/opencode-mem/issues/231), [#232](https://github.com/tickernelz/opencode-mem/issues/232), [#236](https://github.com/tickernelz/opencode-mem/issues/236), and [#237](https://github.com/tickernelz/opencode-mem/issues/237) via [#239](https://github.com/tickernelz/opencode-mem/pull/239).

## Test plan
- [x] Fix PR #239 merged with linked issues
- [x] `package.json` version bumped to `2.24.1`
- [ ] tag `v2.24.1` after merge to trigger npm publish + GitHub Release


Made with [Cursor](https://cursor.com)