### PR TITLE
chore(deps): bump @opencode-ai/* to 1.18.15 and lint-staged to 17.3.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,8 +7,8 @@
       "dependencies": {
         "@huggingface/transformers": "^4.2.0",
         "@libsql/client": "^0.17.4",
-        "@opencode-ai/plugin": "^1.18.4",
-        "@opencode-ai/sdk": "^1.18.4",
+        "@opencode-ai/plugin": "^1.18.15",
+        "@opencode-ai/sdk": "^1.18.15",
         "franc-min": "^6.2.0",
         "hono": "^4.12.32",
         "iso-639-3": "^3.0.1",
@@ -18,7 +18,7 @@
       "devDependencies": {
         "@types/bun": "^1.3.14",
         "husky": "^9.1.7",
-        "lint-staged": "^17.1.1",
+        "lint-staged": "^17.3.0",
         "prettier": "^3.9.6",
         "typescript": "7.0.2",
       },
@@ -130,9 +130,9 @@
 
     "@neon-rs/load": ["@neon-rs/load@0.0.4", "", {}, "sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw=="],
 
-    "@opencode-ai/plugin": ["@opencode-ai/plugin@1.18.10", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@opencode-ai/sdk": "1.18.10", "effect": "4.0.0-beta.83", "zod": "4.1.8" }, "peerDependencies": { "@opentui/core": ">=0.4.5", "@opentui/keymap": ">=0.4.5", "@opentui/solid": ">=0.4.5" }, "optionalPeers": ["@opentui/core", "@opentui/keymap", "@opentui/solid"] }, "sha512-l4R1ulu5wtA0+cCinzdSPkEO8ZCdIgb/ZjltzstIWQqRqeH3H880OabNaeje/ZCkSoAT8c/o9oT3tdjyFP7o7g=="],
+    "@opencode-ai/plugin": ["@opencode-ai/plugin@1.18.15", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@opencode-ai/sdk": "1.18.15", "effect": "4.0.0-beta.83", "zod": "4.1.8" }, "peerDependencies": { "@opentui/core": ">=0.4.5", "@opentui/keymap": ">=0.4.5", "@opentui/solid": ">=0.4.5" }, "optionalPeers": ["@opentui/core", "@opentui/keymap", "@opentui/solid"] }, "sha512-AY10RtFbzLkf951dbLkSGJdBeddeS6ojbjvqCpWnINedqlj2cK/GF91xWjWnlHpqQZ4GABLPCuoSJx8mGmKvCw=="],
 
-    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.18.10", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-K+glWbBp5pfGepZ/6EHvuXY3IpVG2qgsEqF4z9mOiUQUrs6KWN72Vdp15Qsl2TCDbemgHWXKQKgbX3b8PSK2hg=="],
+    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.18.15", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-8sfo9nGiVwesAZW9Wqkvynyn7w4wYaHx1O9qOHpYL65+Bs2XUpHP3kBbZe58gjQydFgk6I74kUF7sqCiPu2arQ=="],
 
     "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
 
@@ -242,7 +242,7 @@
 
     "libsql": ["libsql@0.5.29", "", { "dependencies": { "@neon-rs/load": "^0.0.4", "detect-libc": "2.0.2" }, "optionalDependencies": { "@libsql/darwin-arm64": "0.5.29", "@libsql/darwin-x64": "0.5.29", "@libsql/linux-arm-gnueabihf": "0.5.29", "@libsql/linux-arm-musleabihf": "0.5.29", "@libsql/linux-arm64-gnu": "0.5.29", "@libsql/linux-arm64-musl": "0.5.29", "@libsql/linux-x64-gnu": "0.5.29", "@libsql/linux-x64-musl": "0.5.29", "@libsql/win32-x64-msvc": "0.5.29" }, "os": [ "linux", "win32", "darwin", ], "cpu": [ "arm", "x64", "arm64", ] }, "sha512-8lMP8iMgiBzzoNbAPQ59qdVcj6UaE/Vnm+fiwX4doX4Narook0a4GPKWBEv+CR8a1OwbfkgL18uBfBjWdF0Fzg=="],
 
-    "lint-staged": ["lint-staged@17.2.0", "", { "dependencies": { "picomatch": "^4.0.5", "string-argv": "^0.3.2", "tinyexec": "^1.2.4" }, "optionalDependencies": { "yaml": "^2.9.0" }, "bin": { "lint-staged": "bin/lint-staged.js" } }, "sha512-FchGnFe4i4B1C/a35SPU9bNGPEHSC1+1iV0plLjzBmKVe9klZrlRfSgK6Cw4VeHyqOXbJUXP0vON61uRftNQ0A=="],
+    "lint-staged": ["lint-staged@17.3.0", "", { "dependencies": { "picomatch": "^4.0.5", "string-argv": "^0.3.2", "tinyexec": "^1.2.4" }, "optionalDependencies": { "yaml": "^2.9.0" }, "bin": { "lint-staged": "bin/lint-staged.js" } }, "sha512-woZS3vNe3UKqBaLPvbLOtKRY4tLANpWQhom12MGWqC8Mh1lCOO+WgSwmX2amjJAqTY9BkXYW87fCUH5H9Ph6xw=="],
 
     "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
 

--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
   "dependencies": {
     "@huggingface/transformers": "^4.2.0",
     "@libsql/client": "^0.17.4",
-    "@opencode-ai/plugin": "^1.18.4",
-    "@opencode-ai/sdk": "^1.18.4",
+    "@opencode-ai/plugin": "^1.18.15",
+    "@opencode-ai/sdk": "^1.18.15",
     "franc-min": "^6.2.0",
     "hono": "^4.12.32",
     "iso-639-3": "^3.0.1",
@@ -67,7 +67,7 @@
   "devDependencies": {
     "@types/bun": "^1.3.14",
     "husky": "^9.1.7",
-    "lint-staged": "^17.1.1",
+    "lint-staged": "^17.3.0",
     "prettier": "^3.9.6",
     "typescript": "7.0.2"
   },


### PR DESCRIPTION
## Summary
- Bump `@opencode-ai/plugin` and `@opencode-ai/sdk` from 1.18.10 to 1.18.15 (ranges + lockfile)
- Bump `lint-staged` from 17.2.0 to 17.3.0
- Follow-up to #216; published plugin/SDK type surfaces are identical through 1.18.15, so no app code changes

## Test plan
- [x] `bun install`
- [x] `bun run typecheck`
- [x] `bun test` (405 pass)
- [ ] CI Embedding Backend Verification / Platform Package Smoke


Made with [Cursor](https://cursor.com)