### PR TITLE
refactor(web): use lucide-react v1 canonical icon names

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, type MouseEvent } from "react";
-import { AlertTriangle, Loader, Menu, Plus, RefreshCw, Search, Trash, X } from "lucide-react";
+import { Loader, Menu, Plus, RefreshCw, Search, Trash, TriangleAlert, X } from "lucide-react";
 import { useMemoriesExplorer } from "@/hooks/useMemoriesExplorer";
 import { useUserProfile } from "@/hooks/useUserProfile";
 import { AiCleanupDialog } from "$lib/components/explorer/AiCleanupDialog";
@@ -131,7 +131,7 @@ export default function App() {
           <div className="mx-auto w-full max-w-6xl flex-1 space-y-4 p-4 md:p-6">
             {explorer.showAuthWarning ? (
               <Alert variant="destructive">
-                <AlertTriangle />
+                <TriangleAlert />
                 <AlertDescription>{t("auth-warning-text")}</AlertDescription>
               </Alert>
             ) : null}
@@ -222,7 +222,7 @@ export default function App() {
 
                 {explorer.migrationNeeded ? (
                   <Alert variant="destructive" className="space-y-3">
-                    <AlertTriangle />
+                    <TriangleAlert />
                     <AlertDescription className="space-y-3">
                       <p>{explorer.migrationMessage || t("migration-mismatch")}</p>
                       <label className="flex items-start gap-2 text-sm">

--- a/web/src/lib/components/explorer/MemoryCard.tsx
+++ b/web/src/lib/components/explorer/MemoryCard.tsx
@@ -1,7 +1,7 @@
 import {
   ArrowDown,
   ArrowUp,
-  Edit3,
+  PenLine,
   Link as LinkIcon,
   MessageCircle,
   Pin,
@@ -126,7 +126,7 @@ export function MemoryCard({
                 </Button>
               )}
               <Button variant="ghost" size="icon-xs" onClick={() => onEdit?.(memory.id)}>
-                <Edit3 className="size-3.5" />
+                <PenLine className="size-3.5" />
               </Button>
               <Button
                 variant="destructive"
@@ -257,7 +257,7 @@ export function MemoryCard({
               </Button>
             )}
             <Button variant="ghost" size="icon-xs" onClick={() => onEdit?.(item.id)}>
-              <Edit3 className="size-3.5" />
+              <PenLine className="size-3.5" />
             </Button>
             <Button
               variant="destructive"

--- a/web/src/lib/components/explorer/ProfileView.tsx
+++ b/web/src/lib/components/explorer/ProfileView.tsx
@@ -3,7 +3,7 @@ import {
   Activity,
   ArrowRight,
   Heart,
-  History,
+  RotateCcwClock,
   Info,
   Pencil,
   RefreshCw,
@@ -255,7 +255,7 @@ export function ProfileView({ profile, loading = false, onRefresh, onCleanup }: 
                 {t("btn-refresh")}
               </Button>
               <Button variant="secondary" size="sm" onClick={() => setChangelogOpen(true)}>
-                <History className="size-3.5" />
+                <RotateCcwClock className="size-3.5" />
                 History
               </Button>
             </div>

--- a/web/src/lib/components/ui/sonner.tsx
+++ b/web/src/lib/components/ui/sonner.tsx
@@ -2,7 +2,7 @@ import type { CSSProperties } from "react";
 import {
   CircleCheckIcon,
   InfoIcon,
-  Loader2Icon,
+  LoaderCircleIcon,
   OctagonXIcon,
   TriangleAlertIcon,
 } from "lucide-react";
@@ -24,7 +24,7 @@ function Toaster({ ...props }: ToasterProps) {
         } as CSSProperties
       }
       icons={{
-        loading: <Loader2Icon className="size-4 animate-spin" />,
+        loading: <LoaderCircleIcon className="size-4 animate-spin" />,
         success: <CircleCheckIcon className="size-4" />,
         error: <OctagonXIcon className="size-4" />,
         info: <InfoIcon className="size-4" />,


### PR DESCRIPTION
## Summary
- Follow-up to #219 (`lucide-react` 1.28): switch alias imports to canonical v1 names.
- `AlertTriangle` → `TriangleAlert`, `Edit3` → `PenLine`, `History` → `RotateCcwClock`, `Loader2Icon` → `LoaderCircleIcon`.

## Test plan
- [x] `cd web && bun run check`
- [x] `cd web && bun run build`
- [ ] Spot-check Memory edit button, Profile History button, auth/migration alerts, toast loading icon


Made with [Cursor](https://cursor.com)