### PR TITLE
chore: release v2.24.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-mem",
-  "version": "2.24.1",
+  "version": "2.24.2",
   "description": "OpenCode plugin that gives coding agents persistent memory using local Turso/libSQL vector search",
   "type": "module",
   "main": "dist/plugin.js",


### PR DESCRIPTION
## Summary
- Bump package version to **2.24.2** for a patch release after recent maintenance (including TypeScript 7 for `/web`).
- Triggers the tag-based release workflow once `v2.24.2` is pushed after merge.

## Test plan
- [ ] Confirm `package.json` version is `2.24.2`
- [ ] After merge, tag `v2.24.2` on upstream/main and verify Release workflow (typecheck, build, npm publish, GitHub Release)


Made with [Cursor](https://cursor.com)