### PR TITLE
chore: release v2.24.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-mem",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "description": "OpenCode plugin that gives coding agents persistent memory using local Turso/libSQL vector search",
   "type": "module",
   "main": "dist/plugin.js",


### PR DESCRIPTION
## Summary
- Bump package version to **2.24.3** for the Windows prompt-path normalization fix in #245.
- Triggers the tag-based release workflow once `v2.24.3` is pushed after merge.

## Test plan
- [x] Typecheck passed in the commit hook
- [x] Confirm `package.json` version is `2.24.3`
- [ ] After merge, tag `v2.24.3` on upstream/main and verify the Release workflow

Made with [Cursor](https://cursor.com)