### PR TITLE
fix: mark compacted memory injection part as synthetic

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -973,7 +973,14 @@ export const OpenCodeMemPlugin: Plugin = async (ctx: PluginInput) => {
           await ctx.client.session.prompt({
             path: { id: sessionID },
             body: {
-              parts: [{ id: `prt-compaction-${Date.now()}`, type: "text", text: memoryContext }],
+              parts: [
+                {
+                  id: `prt-compaction-${Date.now()}`,
+                  type: "text",
+                  text: memoryContext,
+                  synthetic: true,
+                },
+              ],
               noReply: true,
               agent,
             },

--- a/tests/compaction-agent-preservation.test.ts
+++ b/tests/compaction-agent-preservation.test.ts
@@ -200,6 +200,19 @@ describe("session.compacted agent preservation (#236)", () => {
     expect(result.parsed?.promptCalls[0]?.body?.noReply).toBe(true);
   });
 
+  it("marks the injected part as synthetic so it is not echoed into the transcript (follow-up to #239)", () => {
+    const result = runCompactionScenario({
+      sessionAgent: "my-orchestrator",
+      memories: [{ memory: "remember this", tags: ["t1"] }],
+      messages: [{ info: { role: "user", agent: "my-orchestrator" } }],
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.parsed?.promptCalls).toHaveLength(1);
+    expect(result.parsed?.promptCalls[0]?.body?.parts?.[0]?.synthetic).toBe(true);
+  });
+
   it("does not call session.prompt when there are no memories", () => {
     const result = runCompactionScenario({
       sessionAgent: "my-orchestrator",


### PR DESCRIPTION
The compaction restore injected the memory dump as a normal text part, so it was echoed into the live session transcript. Mark the part synthetic so the TUI does not render it.

Follow-up to #239, which preserved the session agent on compaction restore but did not mark the injected part synthetic.