### PR TITLE
fix: preserve vector-first ANN query plan

### DIFF
--- a/src/services/turso/vector-search.ts
+++ b/src/services/turso/vector-search.ts
@@ -236,13 +236,13 @@ export class TursoVectorSearch {
           ? `
           SELECT m.id AS id, vector_distance_cos(m.${columnName}, vector32(?)) AS dist
           FROM vector_top_k('${indexName}', vector32(?), ?) AS v
-          JOIN memories m ON m.rowid = v.id
+          CROSS JOIN memories m ON m.rowid = v.id
           WHERE m.${columnName} IS NOT NULL
         `
           : `
           SELECT m.id AS id, vector_distance_cos(m.${columnName}, vector32(?)) AS dist
           FROM vector_top_k('${indexName}', vector32(?), ?) AS v
-          JOIN memories m ON m.rowid = v.id
+          CROSS JOIN memories m ON m.rowid = v.id
           WHERE m.${columnName} IS NOT NULL AND m.container_tag = ?
         `,
         containerTag === "" ? [queryJson, queryJson, k] : [queryJson, queryJson, k, containerTag]

--- a/tests/turso-vector-search.test.ts
+++ b/tests/turso-vector-search.test.ts
@@ -68,4 +68,36 @@ describe("turso vector search", () => {
     );
     expect(limitedResults).toHaveLength(1);
   });
+
+  it("keeps vector_top_k before memories for filtered and unfiltered ANN queries", async () => {
+    const observedSql: string[] = [];
+    const db = {
+      all: async (sql: string) => {
+        observedSql.push(sql);
+        return [];
+      },
+    };
+    const { tursoVectorSearch } = await import("../src/services/turso/vector-search.js");
+    const search = tursoVectorSearch as unknown as {
+      searchKind(
+        database: typeof db,
+        queryJson: string,
+        k: number,
+        containerTag: string,
+        indexName: string,
+        columnName: string
+      ): Promise<Array<{ id: string; similarity: number }>>;
+    };
+
+    await search.searchKind(db, "[1,0]", 10, "", "memories_vec_idx", "vector");
+    await search.searchKind(db, "[1,0]", 10, "opencode_project_test", "memories_vec_idx", "vector");
+
+    expect(observedSql).toHaveLength(2);
+    for (const sql of observedSql) {
+      expect(sql).toContain("FROM vector_top_k");
+      expect(sql).toContain("CROSS JOIN memories m ON m.rowid = v.id");
+      expect(sql.indexOf("vector_top_k")).toBeLessThan(sql.indexOf("memories m"));
+    }
+    expect(observedSql[1]).toContain("m.container_tag = ?");
+  });
 });


### PR DESCRIPTION
## Summary

- use `CROSS JOIN` in both `vector_top_k` query paths so SQLite keeps the virtual table before `memories`
- preserve the existing filtered and unfiltered result semantics
- add a regression test covering both SQL branches

## Why

Issue #247 shows SQLite can reorder the current inner join, drive from `memories`, and evaluate `vector_top_k` once per matching row. `CROSS JOIN` acts as the planner barrier proposed in the issue while keeping the join predicate and filters unchanged.

Closes #247.

## Verification

- `bun run typecheck`
- `bun run format:check`
- `bun run build`
- `bun test` (`408 pass`, `0 fail`)