### PR TITLE
chore: release v2.24.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-mem",
-  "version": "2.24.3",
+  "version": "2.24.4",
   "description": "OpenCode plugin that gives coding agents persistent memory using local Turso/libSQL vector search",
   "type": "module",
   "main": "dist/plugin.js",


### PR DESCRIPTION
## Summary

Bump the package version from `2.24.3` to `2.24.4`. This is a maintenance release covering all independently reviewed fixes merged since v2.24.3.

## Included changes (since v2.24.3)

**Bug fixes:**
- #266 — Include user-scope shards in all-projects tool queries (JojiiOfficial, reviewed by lindixu6-hash)
- #259 — Vector search performance regression fix + Windows web server takeover loop (petra-dot, reviewed by lindixu6-hash)
- #258 — Preserve original provider errors in auto-capture instead of masking with generic config error (lindixu6-hash, reviewed by NaNomicon)
- #257 — Preserve vector-first ANN query plan via CROSS JOIN planner barrier (lindixu6-hash, reviewed by NaNomicon)
- #260 — Keep orphaned linked memories visible in timeline
- #248 — Mark compaction-restored memory injection as synthetic

**Maintenance:**
- #256 — Minor/patch dependency updates

## Verification

- Rebased onto latest `main` (post-#266 merge).
- All six-platform package smoke checks pass on the included PRs.
- `tsc --noEmit` clean.

## Release safety

This PR will **not** be self-merged. It requires independent review and approval before the `v2.24.4` tag is created. The existing Release workflow will verify tag/package version match, publish to npm, and create the GitHub Release.

### Pending owner decisions

- **LICENSE file:** #268 adds the MIT LICENSE text to match package.json metadata. It should be reviewed and merged before or alongside this release.
- **NPM_TOKEN boundary:** the Release workflow uses a repository-level token for `v*` tags. The owner should verify the publish configuration before tagging.