### PR TITLE
feat: show warning toast when opencode provider fails but fallback is configured

### DIFF
--- a/src/services/auto-capture.ts
+++ b/src/services/auto-capture.ts
@@ -107,7 +107,7 @@ async function capturePrompt(
 
         let summaryResult: { summary: string; type: string; tags: string[] } | null;
         try {
-          summaryResult = await generateSummary(context, sessionID, prompt.content, prompt);
+          summaryResult = await generateSummary(ctx, context, sessionID, prompt.content, prompt);
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);
           throw new Error(`Summary generation failed: ${message}`);
@@ -479,6 +479,7 @@ export function buildMarkdownContext(
 }
 
 async function generateSummary(
+  ctx: PluginInput,
   context: string,
   sessionID: string,
   userPrompt: string,
@@ -587,6 +588,26 @@ CAPTURE if: code changed, bug fixed, feature added, decision made`;
       throw opencodeProviderError;
     }
     throw new Error("External API not configured for auto-capture");
+  }
+
+  // Opencode provider failed but a manual fallback is configured — surface a
+  // non-blocking warning so the user knows their primary provider is broken.
+  if (opencodeProviderError && CONFIG.showErrorToasts) {
+    const errMsg =
+      opencodeProviderError instanceof Error
+        ? opencodeProviderError.message
+        : String(opencodeProviderError);
+    const shortReason = errMsg.length > 100 ? errMsg.substring(0, 100) + "..." : errMsg;
+    ctx.client?.tui
+      .showToast({
+        body: {
+          title: "Using fallback provider",
+          message: `OpenCode provider failed (${shortReason}); using configured fallback.`,
+          variant: "warning",
+          duration: 5000,
+        },
+      })
+      .catch(() => {});
   }
 
   const { AIProviderFactory } = await import("./ai/ai-provider-factory.js");


### PR DESCRIPTION
## Summary

When the opencode provider throws and a manual external API fallback is configured, the error was previously only logged to console. The user had no indication that their primary provider was broken and auto-capture was silently using the fallback.

This adds a non-blocking warning toast (5s, variant `warning`) informing the user that the opencode provider failed and the fallback is being used. The original provider error is included (truncated to 100 chars) for debugging.

## Changes

- `generateSummary` now accepts `ctx` to access `client.tui.showToast`.
- After the opencode provider catch block, if `opencodeProviderError` exists AND a manual fallback (`memoryModel` + `memoryApiUrl`) is configured AND `showErrorToasts` is enabled, a warning toast is shown.
- The error toast path (no fallback configured) from #258 is unchanged.
- When no provider error occurs, no toast is shown (existing behavior).

## Testing

- `tsc --noEmit` clean
- Existing auto-capture tests pass (2/2)
- Memory scope tests pass (4/4)

Follow-up from #259 review by @NaNomicon.