### PR TITLE
test: raise ANN plan-check timeout for slow CI runners

### DIFF
--- a/tests/turso-vector-search.test.ts
+++ b/tests/turso-vector-search.test.ts
@@ -101,6 +101,9 @@ describe("turso vector search", () => {
     expect(observedSql[1]).toContain("m.container_tag = ?");
   });
 
+  // Seeding 200 vectors plus a real ANN search can exceed bun's default 5s test
+  // timeout on slower CI runners (observed on windows-latest), so give this
+  // integration-style check explicit headroom. The assertions are unchanged.
   it("returns correct tagged memories from ANN above the k threshold (result-level plan check)", async () => {
     baseDir = mkdtempSync(join(tmpdir(), "turso-vector-ann-"));
 
@@ -166,5 +169,5 @@ describe("turso vector search", () => {
     }
     // Results should be limited to the requested limit.
     expect(results.length).toBeLessThanOrEqual(10);
-  });
+  }, 30000);
 });


### PR DESCRIPTION
## Summary

The result-level ANN plan-check test (`tests/turso-vector-search.test.ts`) seeds 200 vectors and performs a real `vector_top_k` search. On slower CI runners — consistently on `windows-latest` in the current release gate — this exceeds bun's default 5s per-test timeout even though the assertions pass locally and on every other OS.

Give that single integration-style test explicit 30s headroom; no assertion changes.

## Evidence

- release-gate run: https://github.com/tickernelz/opencode-mem/actions/runs/32810250153 (windows package smoke failed 3x, always the same timeout)
- same test passes 3/3 locally and on ubuntu/macos runners
