### PR TITLE
chore: release v2.25.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-mem",
-  "version": "2.24.4",
+  "version": "2.25.0",
   "description": "OpenCode plugin that gives coding agents persistent memory using local Turso/libSQL vector search",
   "type": "module",
   "main": "dist/plugin.js",


### PR DESCRIPTION
## Summary

- bump `opencode-mem` from `2.24.4` to `2.25.0`
- release the orcarouter memory provider preset (#254)
- release correctness & data-integrity fixes for user profiles and turso sharding (#252)
- release dependabot minor-and-patch dependency group updates (#271)
- include integration fixes from #272 (bun-types 1.3.14 override pin, #265 error-propagation preservation)
- includes the ANN plan-check timeout headroom from #274 that unblocked the Windows CI gate

Supersedes #273 (blocked by the flaky Windows timeout now fixed by #274).

## Verification

- frozen installs root + web, typecheck, production build: pass
- full test suite: **444 passed / 0 failed / 1 skipped**
- package dry-run: version `2.25.0`, `dist/plugin.js` and `dist/web/index.html` present
