### PR TITLE
fix: reduce DiskANN index storage overhead

### DIFF
--- a/src/services/turso/shard-manager.ts
+++ b/src/services/turso/shard-manager.ts
@@ -328,13 +328,23 @@ export class TursoShardManager {
       {
         sql: `
           CREATE INDEX IF NOT EXISTS memories_vec_idx
-          ON memories (libsql_vector_idx(vector, 'metric=cosine'))
+          ON memories (libsql_vector_idx(
+            vector,
+            'metric=cosine',
+            'compress_neighbors=float8',
+            'max_neighbors=20'
+          ))
         `,
       },
       {
         sql: `
           CREATE INDEX IF NOT EXISTS memories_tags_vec_idx
-          ON memories (libsql_vector_idx(tags_vector, 'metric=cosine'))
+          ON memories (libsql_vector_idx(
+            tags_vector,
+            'metric=cosine',
+            'compress_neighbors=float8',
+            'max_neighbors=20'
+          ))
           WHERE tags_vector IS NOT NULL
         `,
       },

--- a/tests/turso-vector-search.test.ts
+++ b/tests/turso-vector-search.test.ts
@@ -33,6 +33,18 @@ describe("turso vector search", () => {
     const shard = await tursoShardManager.createShard("project", scopeHash, 0);
     const db = await tursoConnectionManager.getConnection(shard.dbPath);
 
+    const indexDefinitions = await db.all<{ name: string; sql: string }>(`
+      SELECT name, sql
+      FROM sqlite_schema
+      WHERE type = 'index' AND name IN ('memories_vec_idx', 'memories_tags_vec_idx')
+    `);
+    expect(indexDefinitions).toHaveLength(2);
+    for (const index of indexDefinitions) {
+      expect(index.sql).toContain("'metric=cosine'");
+      expect(index.sql).toContain("'compress_neighbors=float8'");
+      expect(index.sql).toContain("'max_neighbors=20'");
+    }
+
     await tursoVectorSearch.insertVector(db, {
       id: "mem_test_1",
       content: "Turso native vector search",
@@ -43,6 +55,25 @@ describe("turso vector search", () => {
       createdAt: Date.now(),
       updatedAt: Date.now(),
     });
+
+    const contentIndexHit = await db.get<{ id: string }>(
+      `
+        SELECT m.id AS id
+        FROM vector_top_k('memories_vec_idx', vector32(?), 1) AS v
+        CROSS JOIN memories m ON m.rowid = v.id
+      `,
+      [JSON.stringify(Array.from(vector))]
+    );
+    const tagsIndexHit = await db.get<{ id: string }>(
+      `
+        SELECT m.id AS id
+        FROM vector_top_k('memories_tags_vec_idx', vector32(?), 1) AS v
+        CROSS JOIN memories m ON m.rowid = v.id
+      `,
+      [JSON.stringify(Array.from(tagsVector))]
+    );
+    expect(contentIndexHit?.id).toBe("mem_test_1");
+    expect(tagsIndexHit?.id).toBe("mem_test_1");
 
     await tursoVectorSearch.insertVector(db, {
       id: "mem_test_no_tags",


### PR DESCRIPTION
## Summary

- store DiskANN neighbor vectors as `float8` for both content and tag indexes
- cap `max_neighbors` at 20 so high-dimensional embeddings do not inherit the much larger libSQL default
- assert the persisted SQL definitions and exercise direct `vector_top_k` lookups through both tuned indexes

## Scope

This deliberately changes newly created indexes only. Existing shards retain their current index definitions until a separate failure-safe rebuild/VACUUM migration is designed, so this patch does not risk leaving an existing shard without an index.

Addresses the new-shard portion of #277.

## Validation

- `bun test tests/turso-vector-search.test.ts -t "inserts and searches memories"` — 1 pass
- `bun run typecheck` — pass
- `bun run build` — pass
- full local Windows suite — 446 pass; 2 unrelated platform/timing failures: an `EBUSY` file rename in the legacy migrator test and the existing 30-second 200-vector ANN test timing out at 35.5 seconds. The latter was slower and eventually crashed Bun when repeated with the unmodified upstream index definition.