### PR TITLE
fix: show matched memory count during search

### DIFF
--- a/tests/memory-count.test.ts
+++ b/tests/memory-count.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+import { getDisplayedMemoryCount } from "../web/src/lib/memory-count";
+
+describe("getDisplayedMemoryCount", () => {
+  test("shows matched results while search is active", () => {
+    expect(getDisplayedMemoryCount(true, 3, 120)).toBe(3);
+    expect(getDisplayedMemoryCount(true, 0, 120)).toBe(0);
+  });
+
+  test("restores the store total when search is cleared", () => {
+    expect(getDisplayedMemoryCount(false, 3, 120)).toBe(120);
+  });
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -16,6 +16,7 @@ import { Label } from "$lib/components/ui/label";
 import { Toaster } from "$lib/components/ui/sonner";
 import { Textarea } from "$lib/components/ui/textarea";
 import { cycleLanguage, getLanguage, useI18n } from "$lib/i18n";
+import { getDisplayedMemoryCount } from "$lib/memory-count";
 import { initRouter, navigate, ROUTES, useAppView } from "$lib/router";
 
 const MEMORY_TYPES = [
@@ -142,7 +143,15 @@ export default function App() {
               </h1>
               {currentView === "project" ? (
                 <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                  <span>{t("text-total", { count: explorer.statsTotal })}</span>
+                  <span>
+                    {t("text-total", {
+                      count: getDisplayedMemoryCount(
+                        explorer.isSearching,
+                        explorer.totalItems,
+                        explorer.statsTotal
+                      ),
+                    })}
+                  </span>
                   {explorer.refreshing ? <Loader className="size-3.5 animate-spin" /> : null}
                 </div>
               ) : null}

--- a/web/src/lib/memory-count.ts
+++ b/web/src/lib/memory-count.ts
@@ -1,0 +1,7 @@
+export function getDisplayedMemoryCount(
+  isSearching: boolean,
+  searchTotal: number,
+  storeTotal: number
+): number {
+  return isSearching ? searchTotal : storeTotal;
+}


### PR DESCRIPTION
## Summary
- show the search result total while a query is active
- restore the store-wide total when the query is cleared
- cover matched, zero-result, and cleared-search states with regression tests

Closes #288

## Validation
- bun test tests/memory-count.test.ts (2 passed)
- bun run typecheck
- production web build
- Prettier check on changed files
- git diff --check