### PR TITLE
test: raise ANN vector search timeout for Windows CI runners

### DIFF
--- a/tests/turso-vector-search.test.ts
+++ b/tests/turso-vector-search.test.ts
@@ -200,5 +200,5 @@ describe("turso vector search", () => {
     }
     // Results should be limited to the requested limit.
     expect(results.length).toBeLessThanOrEqual(10);
-  }, 30000);
+  }, 60000);
 });


### PR DESCRIPTION
## Summary
- Raises the ANN plan-check test timeout in 	ests/turso-vector-search.test.ts from 30s to 60s.
- On Windows and slow CI runners, inserting 200 high-dimensional vectors and executing the native ANN search could occasionally exceed 30s by a few hundred milliseconds, causing intermittent timeouts.

## Validation
- un test tests/turso-vector-search.test.ts (3/3 pass)