### PR TITLE
docs(minimax): refresh current model metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ Manual `memoryProvider` modes:
 - `openai-chat`: OpenAI Chat Completions compatible API with tool/function calling. This can work with compatible proxies such as LiteLLM only when the selected upstream model and proxy preserve tool calls.
 - `openai-responses`: OpenAI Responses API with function-call output.
 - `anthropic`: Anthropic Messages API with tool use.
-- `minimax`: MiniMax Anthropic Messages-compatible endpoint. Set `memoryApiUrl` to the global endpoint (`https://api.minimax.io`) or the China endpoint (`https://api.minimaxi.com`); the `/anthropic/v1/messages` path and `x-api-key` header are applied automatically. MiniMax text models such as `MiniMax-M3` support the adaptive thinking modes used by this plugin via `memoryExtraParams`.
+- `minimax`: MiniMax Anthropic Messages-compatible endpoint. Set `memoryApiUrl` to the global endpoint (`https://api.minimax.io/anthropic`) or the China endpoint (`https://api.minimaxi.com/anthropic`); the `/v1/messages` path and `x-api-key` header are applied automatically. Current models include `MiniMax-M3` (1,000,000-token context; text, image, and video input; adaptive or disabled thinking) and `MiniMax-M2.7` (204,800-token context; text input; always-on thinking). `MiniMax-M3` supports adaptive thinking through `memoryExtraParams`.
 - `orcarouter`: OpenAI-compatible model gateway with namespaced model IDs. `memoryApiUrl` and `memoryModel` are optional — they default to `https://api.orcarouter.ai/v1` and `orcarouter/auto` (a routing alias that selects a capable model per request). If you set `memoryModel`, use a namespaced ID such as `openai/gpt-5.5` or `deepseek/deepseek-v4-flash`; OrcaRouter rejects bare model names. Example:
   ```jsonc
   "memoryProvider": "orcarouter",

--- a/src/config.ts
+++ b/src/config.ts
@@ -416,10 +416,12 @@ const CONFIG_TEMPLATE = `{
 
   // MiniMax (Anthropic Messages-compatible endpoint, with session support):
   //   "memoryProvider": "minimax"
-  //   "memoryModel": "MiniMax-M3"
-  //   "memoryApiUrl": "https://api.minimax.io"        // global endpoint
+  //   "memoryModel": "MiniMax-M3"                  // 1,000,000-token context; text, image, video
+  //   // Alternative: "MiniMax-M2.7"                // 204,800-token context; text
+  //   "memoryApiUrl": "https://api.minimax.io/anthropic" // global endpoint
   //   "memoryApiKey": "<MiniMax API key>"
-  //   // China endpoint: "memoryApiUrl": "https://api.minimaxi.com"
+  //   // China endpoint: "memoryApiUrl": "https://api.minimaxi.com/anthropic"
+  //   // MiniMax-M3 supports adaptive or disabled thinking; MiniMax-M2.7 thinking is always on.
   //   // Optional adaptive thinking for MiniMax-M3:
   //   "memoryExtraParams": { "thinking": { "type": "adaptive" } }
 

--- a/src/services/ai/providers/minimax.ts
+++ b/src/services/ai/providers/minimax.ts
@@ -3,6 +3,44 @@ import { AISessionManager } from "../session/ai-session-manager.js";
 import { AnthropicMessagesProvider } from "./anthropic-messages.js";
 import type { AIProviderType } from "../session/session-types.js";
 
+export interface MiniMaxModelMetadata {
+  contextWindow: number;
+  pricingUsdPerMillionTokens: {
+    input: number;
+    output: number;
+    cacheRead: number;
+    cacheWrite: number | null;
+  };
+  inputModalities: readonly string[];
+  thinkingModes: readonly string[];
+}
+
+/** Current text model capabilities and pricing. */
+export const MINIMAX_MODEL_METADATA = {
+  "MiniMax-M3": {
+    contextWindow: 1_000_000,
+    pricingUsdPerMillionTokens: {
+      input: 0.6,
+      output: 2.4,
+      cacheRead: 0.12,
+      cacheWrite: null,
+    },
+    inputModalities: ["text", "image", "video"],
+    thinkingModes: ["adaptive", "disabled"],
+  },
+  "MiniMax-M2.7": {
+    contextWindow: 204_800,
+    pricingUsdPerMillionTokens: {
+      input: 0.3,
+      output: 1.2,
+      cacheRead: 0.06,
+      cacheWrite: 0.375,
+    },
+    inputModalities: ["text"],
+    thinkingModes: ["always_on"],
+  },
+} as const satisfies Record<string, MiniMaxModelMetadata>;
+
 /**
  * MiniMax provider.
  *

--- a/tests/minimax-provider.test.ts
+++ b/tests/minimax-provider.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { MiniMaxProvider } from "../src/services/ai/providers/minimax.js";
+import { MINIMAX_MODEL_METADATA, MiniMaxProvider } from "../src/services/ai/providers/minimax.js";
 import { AIProviderFactory } from "../src/services/ai/ai-provider-factory.js";
 import type { ChatCompletionTool } from "../src/services/ai/tools/tool-schema.js";
 
@@ -211,6 +211,33 @@ describe("MiniMaxProvider", () => {
     expect(capturedBody?.max_tokens).toBeDefined();
     expect(result.success).toBe(true);
     expect((result.data as any).memory).toBe("captured fact");
+  });
+});
+
+describe("MiniMax model metadata", () => {
+  it("describes the current models", () => {
+    expect(MINIMAX_MODEL_METADATA["MiniMax-M3"]).toEqual({
+      contextWindow: 1_000_000,
+      pricingUsdPerMillionTokens: {
+        input: 0.6,
+        output: 2.4,
+        cacheRead: 0.12,
+        cacheWrite: null,
+      },
+      inputModalities: ["text", "image", "video"],
+      thinkingModes: ["adaptive", "disabled"],
+    });
+    expect(MINIMAX_MODEL_METADATA["MiniMax-M2.7"]).toEqual({
+      contextWindow: 204_800,
+      pricingUsdPerMillionTokens: {
+        input: 0.3,
+        output: 1.2,
+        cacheRead: 0.06,
+        cacheWrite: 0.375,
+      },
+      inputModalities: ["text"],
+      thinkingModes: ["always_on"],
+    });
   });
 });
 


### PR DESCRIPTION
Reason: Refresh MiniMax model metadata and regional endpoint guidance to match the current text model configuration.

## Changes

- add typed metadata for MiniMax-M3 and MiniMax-M2.7, including context windows, token pricing, input modalities, and thinking modes
- update the generated configuration guidance and README with current regional Anthropic base URLs and model capabilities
- cover both current model metadata entries in the provider test suite

## Checks

- `bun test tests/minimax-provider.test.ts`
- `bun run typecheck`
- `bun run build`
- `bun test`
- `prettier --check README.md src/config.ts src/services/ai/providers/minimax.ts tests/minimax-provider.test.ts`
